### PR TITLE
chore(regression): make JobScheduler init public

### DIFF
--- a/Sources/Jobs/Scheduler/JobSchedule.swift
+++ b/Sources/Jobs/Scheduler/JobSchedule.swift
@@ -57,7 +57,7 @@ public struct JobSchedule: MutableCollection, Sendable {
         let jobParameters: any JobParameters
         let accuracy: ScheduleAccuracy
 
-        init(job: JobParameters, schedule: Schedule, accuracy: ScheduleAccuracy = .latest) {
+        public init(job: JobParameters, schedule: Schedule, accuracy: ScheduleAccuracy = .latest) {
             let nextScheduledDate = schedule.nextDate() ?? .distantFuture
             self.nextScheduledDate = nextScheduledDate
             self.schedule = schedule


### PR DESCRIPTION
Make JobScheduler Element init public: 

Currently, this is not possible with the current release

```swift
let jobSchedule = JobSchedule([
	.init(job: SomeJobParameters(), schedule: .hourly())
])
```
