### PR TITLE
feat(retry with backoff): Retry with backoff

### DIFF
--- a/Sources/Jobs/EncodableJob.swift
+++ b/Sources/Jobs/EncodableJob.swift
@@ -19,18 +19,9 @@ struct EncodableJob<Parameters: Codable & Sendable>: Encodable, Sendable {
     let id: JobIdentifier<Parameters>
     let data: JobInstanceData<Parameters>
 
-    init(
-        id: JobIdentifier<Parameters>,
-        parameters: Parameters,
-        queuedAt: Date,
-        attempts: Int
-    ) {
+    init(id: JobIdentifier<Parameters>, parameters: Parameters, queuedAt: Date, attempts: Int) {
         self.id = id
-        self.data = .init(
-            parameters: parameters,
-            queuedAt: queuedAt,
-            attempts: attempts
-        )
+        self.data = .init(parameters: parameters, queuedAt: queuedAt, attempts: attempts)
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Sources/Jobs/EncodableJob.swift
+++ b/Sources/Jobs/EncodableJob.swift
@@ -19,9 +19,20 @@ struct EncodableJob<Parameters: Codable & Sendable>: Encodable, Sendable {
     let id: JobIdentifier<Parameters>
     let data: JobInstanceData<Parameters>
 
-    init(id: JobIdentifier<Parameters>, parameters: Parameters, queuedAt: Date) {
+    init(
+        id: JobIdentifier<Parameters>,
+        parameters: Parameters,
+        queuedAt: Date,
+        delayUntil: Date?,
+        attempts: Int
+    ) {
         self.id = id
-        self.data = .init(parameters: parameters, queuedAt: queuedAt)
+        self.data = .init(
+            parameters: parameters,
+            queuedAt: queuedAt,
+            delayUntil: delayUntil,
+            attempts: attempts
+        )
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Sources/Jobs/JobInstance.swift
+++ b/Sources/Jobs/JobInstance.swift
@@ -25,7 +25,7 @@ protocol JobInstanceProtocol: Sendable {
     /// Time job was queued
     var queuedAt: Date { get }
     /// Number of attempts so far
-    var attempts: Int { get }
+    var attempts: Int? { get }
     /// Job parameters
     var parameters: Parameters { get }
     /// Function to execute the job
@@ -40,12 +40,12 @@ extension JobInstanceProtocol {
 
     /// Number of remaining attempts
     public var remainingAttempts: Int {
-        maxRetryCount - attempts
+        maxRetryCount - (attempts ?? 0)
     }
 
     /// If job failed after n number of attempts
     public var didFail: Bool {
-        attempts >= maxRetryCount
+        (attempts ?? 0) >= maxRetryCount
     }
 }
 
@@ -65,7 +65,7 @@ struct JobInstance<Parameters: Codable & Sendable>: JobInstanceProtocol {
     /// Time job was queued
     var queuedAt: Date { self.data.queuedAt }
     /// Number of attempts so far
-    var attempts: Int { self.data.attempts }
+    var attempts: Int? { self.data.attempts ?? 0 }
     /// Job parameters
     var parameters: Parameters { self.data.parameters }
 
@@ -86,7 +86,7 @@ struct JobInstanceData<Parameters: Codable & Sendable>: Codable {
     /// Date job was queued
     let queuedAt: Date
     /// Number of attempts so far
-    let attempts: Int
+    let attempts: Int?
 
     // keep JSON strings small to improve decode speed
     private enum CodingKeys: String, CodingKey {

--- a/Sources/Jobs/JobInstance.swift
+++ b/Sources/Jobs/JobInstance.swift
@@ -24,22 +24,28 @@ protocol JobInstanceProtocol: Sendable {
     var maxRetryCount: Int { get }
     /// Time job was queued
     var queuedAt: Date { get }
-    /// Time to execute a job
-    var delayUntil: Date? { get }
     /// Number of attempts so far
     var attempts: Int { get }
+    /// Job parameters
+    var parameters: Parameters { get }
     /// Function to execute the job
     func execute(context: JobContext) async throws
 }
 
 extension JobInstanceProtocol {
-    /// name of job type
+    /// Name of job type
     public var name: String {
         id.name
     }
 
+    /// Number of remaining attempts
     public var remainingAttempts: Int {
         maxRetryCount - attempts
+    }
+
+    /// If job failed after n number of attempts
+    public var didFail: Bool {
+        attempts >= maxRetryCount
     }
 }
 
@@ -60,8 +66,8 @@ struct JobInstance<Parameters: Codable & Sendable>: JobInstanceProtocol {
     var queuedAt: Date { self.data.queuedAt }
     /// Number of attempts so far
     var attempts: Int { self.data.attempts }
-    /// When to execute a job
-    var delayUntil: Date? { self.data.delayUntil }
+    /// Job parameters
+    var parameters: Parameters { self.data.parameters }
 
     func execute(context: JobContext) async throws {
         try await self.job.execute(self.data.parameters, context: context)

--- a/Sources/Jobs/JobParameters.swift
+++ b/Sources/Jobs/JobParameters.swift
@@ -25,8 +25,8 @@ extension JobParameters {
     }
 
     /// Added so it is possible to push JobParameters referenced as Existentials to a Job queue
-    @discardableResult public func push<Queue: JobQueueDriver>(to jobQueue: JobQueue<Queue>) async throws -> Queue.JobID {
-        try await jobQueue.push(self)
+    @discardableResult public func push<Queue: JobQueueDriver>(to jobQueue: JobQueue<Queue>, options: JobOptions = .init()) async throws -> Queue.JobID {
+        try await jobQueue.push(self, options: options)
     }
 }
 
@@ -34,9 +34,10 @@ extension JobQueue {
     ///  Push Job onto queue
     /// - Parameters:
     ///   - parameters: parameters for the job
+    ///   - options: JobOptions
     /// - Returns: Identifier of queued job
-    @discardableResult public func push<Parameters: JobParameters>(_ parameters: Parameters) async throws -> Queue.JobID {
-        return try await self.push(id: Parameters.jobID, parameters: parameters)
+    @discardableResult public func push<Parameters: JobParameters>(_ parameters: Parameters, options: JobOptions = .init()) async throws -> Queue.JobID {
+        return try await self.push(id: Parameters.jobID, parameters: parameters, options: options)
     }
 
     ///  Register job type

--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -43,9 +43,17 @@ public struct JobQueue<Queue: JobQueueDriver>: Service {
     ///   - parameters: parameters for the job
     /// - Returns: Identifier of queued job
     @discardableResult public func push<Parameters: Codable & Sendable>(
-        id: JobIdentifier<Parameters>, parameters: Parameters
+        id: JobIdentifier<Parameters>,
+        parameters: Parameters,
+        delayUntil: Date? = nil
     ) async throws -> Queue.JobID {
-        let jobRequest = EncodableJob(id: id, parameters: parameters, queuedAt: .now)
+        let jobRequest = EncodableJob(
+            id: id,
+            parameters: parameters,
+            queuedAt: .now,
+            delayUntil: delayUntil,
+            attempts: 0
+        )
         let buffer = try JSONEncoder().encodeAsByteBuffer(jobRequest, allocator: ByteBufferAllocator())
         Meter(label: "swift_jobs_meter", dimensions: [("status", "queued")]).increment()
         let id = try await self.queue.push(buffer)

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -30,9 +30,6 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == QueuedJ
     ///   - options: JobOptions
     /// - Returns: Identifier of queued jobs
     func push(_ buffer: ByteBuffer, options: JobOptions) async throws -> JobID
-    /// Retry a job that's been in a queue
-    ///  - Parameter jobId: JobID
-    func retry(jobId: JobID, buffer: ByteBuffer, options: JobOptions) async throws
     /// This is called to say job has finished processing and it can be deleted
     func finished(jobId: JobID) async throws
     /// This is called to say job has failed to run and should be put aside

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -64,8 +64,8 @@ extension JobQueueDriver {
     func encode<Parameters: Codable & Sendable>(
         id: JobIdentifier<Parameters>,
         parameters: Parameters
-    ) throws -> (buffer: ByteBuffer, jobName: String) {
+    ) throws -> ByteBuffer {
         let jobRequest = EncodableJob(id: id, parameters: parameters, queuedAt: .now, attempts: 0)
-        return try (buffer: JSONEncoder().encodeAsByteBuffer(jobRequest, allocator: ByteBufferAllocator()), jobName: id.name)
+        return try JSONEncoder().encodeAsByteBuffer(jobRequest, allocator: ByteBufferAllocator())
     }
 }

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -25,7 +25,9 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == QueuedJ
     /// Called when JobQueueHandler is initialised with this queue
     func onInit() async throws
     /// Push Job onto queue
-    /// - Parameter options: JobExecutionOptions
+    /// - Parameters
+    ///   - buffer: ByteBuffer
+    ///   - options: JobOptions
     /// - Returns: Identifier of queued jobs
     func push(_ buffer: ByteBuffer, options: JobOptions) async throws -> JobID
     /// Retry a job that's been in a queue

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -220,7 +220,7 @@ extension JobQueueHandler {
     // It would be nice to provide different retry different algorithms options
     // or no backoff retries at all
     private func jitter() -> Double {
-        Double(arc4random_uniform(500))
+        Double.random(in: 5.0..<15.0)
     }
 
     func backoff(

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -122,9 +122,11 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
 
                 let delay = self.backoff(attempts: attempts)
 
-                try await self.queue.retry(
-                    jobId: queuedJob.id,
-                    buffer: self.queue.encode(job, attempts: attempts),
+                // remove from processing lists
+                try await self.queue.finished(jobId: queuedJob.id)
+                // push new job in the queue
+                _ = try await self.queue.push(
+                    self.queue.encode(job, attempts: attempts),
                     options: .init(
                         delayUntil: delay
                     )

--- a/Sources/Jobs/JobQueueOptions.swift
+++ b/Sources/Jobs/JobQueueOptions.swift
@@ -16,9 +16,6 @@ import struct Foundation.TimeInterval
 
 /// JobQueueOptions
 public struct JobQueueOptions: Sendable {
-    /// Backoff factor default 2, but isn't used
-    /// since we ar esuing exp2 instead of pow
-    public var backoffFactor: Double
     /// Maximum Backoff - default is 120.0 seconds
     public var maximumBackoff: TimeInterval
     /// Maximum jitter - default is 15 seconds
@@ -30,13 +27,18 @@ public struct JobQueueOptions: Sendable {
         Double.random(in: self.minJitter..<self.maxJitter)
     }
 
+    /// Initialize a JobQueueOptions
+    /// The current backoff computation uses jitters
+    /// see Wikipedia if  not familiar  with the topic https://en.wikipedia.org/wiki/Exponential_backoff
+    /// - Parameters:
+    ///   - maximumBackoff: maximum backoff allowed, default 120 seconds
+    ///   - maxJitter: maximum jitter
+    ///   - minJitter: minimum jitter
     public init(
-        backoffFactor: Double = 2,
         maximumBackoff: TimeInterval = 120.0,
         maxJitter: TimeInterval = 15.0,
         minJitter: TimeInterval = 5.0
     ) {
-        self.backoffFactor = backoffFactor
         self.maximumBackoff = maximumBackoff
         self.maxJitter = maxJitter
         self.minJitter = minJitter

--- a/Sources/Jobs/JobQueueOptions.swift
+++ b/Sources/Jobs/JobQueueOptions.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.TimeInterval
+
+/// JobQueueOptions
+public struct JobQueueOptions: Sendable {
+    /// Backoff factor default 2, but isn't used
+    /// since we ar esuing exp2 instead of pow
+    public var backoffFactor: Double
+    /// Maximum Backoff - default is 120.0 seconds
+    public var maximumBackoff: TimeInterval
+    /// Maximum jitter - default is 15 seconds
+    public var maxJitter: TimeInterval
+    /// Minimum jitter - default is 5 seconds
+    public var minJitter: TimeInterval
+    /// Computes a random jitter between minJitter and maxJitter
+    internal var jitter: Double {
+        Double.random(in: self.minJitter..<self.maxJitter)
+    }
+
+    public init(
+        backoffFactor: Double = 2,
+        maximumBackoff: TimeInterval = 120.0,
+        maxJitter: TimeInterval = 15.0,
+        minJitter: TimeInterval = 5.0
+    ) {
+        self.backoffFactor = backoffFactor
+        self.maximumBackoff = maximumBackoff
+        self.maxJitter = maxJitter
+        self.minJitter = minJitter
+    }
+}

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -50,10 +50,6 @@ public final class MemoryQueue: JobQueueDriver {
         return try await self.queue.push(buffer, options: options)
     }
 
-    public func retry(jobId: JobID, buffer: ByteBuffer, options: JobOptions) async throws {
-        await self.queue.updateJob(jobId, buffer: buffer, options: options)
-    }
-
     public func finished(jobId: JobID) async throws {
         await self.queue.clearPendingJob(jobId: jobId)
     }
@@ -90,11 +86,6 @@ public final class MemoryQueue: JobQueueDriver {
             let id = JobID()
             self.queue.append((job: QueuedJob(id: id, jobBuffer: jobBuffer), options: options))
             return id
-        }
-
-        func updateJob(_ jobId: JobID, buffer: ByteBuffer, options: JobOptions) {
-            self.clearPendingJob(jobId: jobId)
-            self.queue.append((job: QueuedJob(id: jobId, jobBuffer: buffer), options: options))
         }
 
         func clearPendingJob(jobId: JobID) {

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -24,13 +24,11 @@ public final class MemoryQueue: JobQueueDriver {
     /// queue of jobs
     fileprivate let queue: Internal
     private let onFailedJob: @Sendable (QueuedJob<JobID>, any Error) -> Void
-    private let onRetryJob: @Sendable (QueuedJob<JobID>) -> Void
 
     /// Initialise In memory job queue
     public init(onFailedJob: @escaping @Sendable (QueuedJob<JobID>, any Error) -> Void = { _, _ in }) {
         self.queue = .init()
         self.onFailedJob = onFailedJob
-        self.onRetryJob = { _ in }
     }
 
     /// Stop queue serving more jobs
@@ -54,7 +52,6 @@ public final class MemoryQueue: JobQueueDriver {
 
     public func retry(jobId: JobID, buffer: ByteBuffer, options: JobOptions) async throws {
         await self.queue.updateJob(jobId, buffer: buffer, options: options)
-        self.onRetryJob(.init(id: jobId, jobBuffer: buffer))
     }
 
     public func finished(jobId: JobID) async throws {

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -191,7 +191,7 @@ final class JobsTests: XCTestCase {
                 $0.append(parameters)
             }
             expectation.fulfill()
-            // swift 5.9 test fix
+
             if parameters == delayedJobParameterValue {
                 delayedJob.wrappingDecrement(by: 1, ordering: .relaxed)
             }
@@ -202,7 +202,7 @@ final class JobsTests: XCTestCase {
             delayedJob.wrappingIncrement(by: 1, ordering: .relaxed)
             try await jobQueue.push(id: job2, parameters: 10)
             XCTAssertEqual(delayedJob.load(ordering: .relaxed), 2)
-            await fulfillment(of: [expectation], timeout: 10)
+            await fulfillment(of: [expectation], timeout: 5)
             XCTAssertEqual(delayedJob.load(ordering: .relaxed), 1)
         }
 

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -121,7 +121,14 @@ final class JobsTests: XCTestCase {
         struct FailedError: Error {}
         var logger = Logger(label: "JobsTests")
         logger.logLevel = .trace
-        let jobQueue = JobQueue(.memory, logger: logger)
+        let jobQueue = JobQueue(
+            .memory,
+            logger: logger,
+            options: .init(
+                maxJitter: 0.25,
+                minJitter: 0.01
+            )
+        )
         jobQueue.registerJob(id: jobIdentifer, maxRetryCount: 3) { _, _ in
 
             defer {
@@ -151,7 +158,12 @@ final class JobsTests: XCTestCase {
         logger.logLevel = .trace
         let jobQueue = JobQueue(
             MemoryQueue { _, _ in failedJobCount.wrappingIncrement(by: 1, ordering: .relaxed) },
-            logger: logger
+            logger: logger,
+            options: .init(
+                maximumBackoff: 0.5,
+                maxJitter: 0.01,
+                minJitter: 0.0
+            )
         )
         jobQueue.registerJob(id: jobIdentifer, maxRetryCount: 3) { _, _ in
             expectation.fulfill()

--- a/Tests/JobsTests/MetricsTests.swift
+++ b/Tests/JobsTests/MetricsTests.swift
@@ -322,7 +322,12 @@ final class MetricsTests: XCTestCase {
         logger.logLevel = .trace
         let jobQueue = JobQueue(
             MemoryQueue { _, _ in failedJobCount.wrappingIncrement(by: 1, ordering: .relaxed) },
-            logger: logger
+            logger: logger,
+            options: .init(
+                maximumBackoff: 0.5,
+                maxJitter: 0.01,
+                minJitter: 0.0
+            )
         )
         jobQueue.registerJob(id: jobIdentifer, maxRetryCount: 3) { _, _ in
             expectation.fulfill()


### PR DESCRIPTION
First pass at adding retry with exponential backoff

I don't like the this implementation for the following reasons:

1 - The current execution will sleep
2 - A Job might cause the current execution to sleep for a while based on the maxAttempt passed.

I think we should update the Encodable job structure with the followings

1 - Delayed until (Time when to process this job)
2 - Remaining attempt count 

Adding the above would also afford us with allowing a job to be queued now and get process later. 

I look forward to your feedback on how best to proceed here CC: @adam-fowler @Joannis 