### PR TITLE
chore(bug): fixed a bug where processing step was over counting

### DIFF
--- a/Sources/Jobs/JobMetricsHelper.swift
+++ b/Sources/Jobs/JobMetricsHelper.swift
@@ -45,6 +45,13 @@ internal enum JobMetricsHelper {
         error: Error? = nil,
         retrying: Bool = false
     ) {
+        // We can decrement processing jobs here because this func called
+        // on complete, failed e.t.c
+        Meter(label: JobMetricsHelper.meterLabel, dimensions: [
+            ("status", JobMetricsHelper.JobStatus.processing.rawValue),
+            ("name", name),
+        ]).decrement()
+
         if retrying {
             Counter(
                 label: Self.metricsLabel,

--- a/Sources/Jobs/JobMetricsHelper.swift
+++ b/Sources/Jobs/JobMetricsHelper.swift
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Dispatch
+import Metrics
+
+/// OTEL labels and dimensions
+internal enum JobMetricsHelper {
+    /// Metrics label
+    static let metricsLabel: String = "swift.jobs"
+    /// Meter label for Processsing, Queued, Failed and Completed
+    static let meterLabel: String = "swift.jobs.meter"
+    /// Meter label for discarded jobs
+    static let discardedMeter: String = "swift.jobs.discarded"
+    /// Used for the histogram which can be useful to see by job status
+    enum JobStatus: String, Codable, Sendable {
+        case queued
+        case processing
+        case retried
+        case cancelled
+        case failed
+        case succeeded
+    }
+
+    /// Update job metrics
+    /// - Parameters:
+    ///   - name: String Job name
+    ///   - startTime: UInt64 when the job started
+    ///   - error: Error? job error
+    ///   - retrying: Bool if the job is being retried
+    ///
+    static func updateMetrics(
+        for name: String,
+        startTime: UInt64,
+        error: Error? = nil,
+        retrying: Bool = false
+    ) {
+        if retrying {
+            Counter(
+                label: Self.metricsLabel,
+                dimensions: [("name", name), ("status", JobStatus.retried.rawValue)]
+            ).increment()
+            // Guard against negative queue values, this is needed because we call
+            // the job queue directly in the retrying step
+            Meter(label: JobMetricsHelper.meterLabel, dimensions: [
+                ("status", JobMetricsHelper.JobStatus.queued.rawValue),
+                ("name", name),
+            ]).increment()
+            return
+        }
+
+        let jobStatus: JobStatus = if let error {
+            if error is CancellationError {
+                .cancelled
+            } else {
+                .failed
+            }
+        } else {
+            .succeeded
+        }
+
+        let dimensions: [(String, String)] = [
+            ("name", name),
+            ("status", jobStatus.rawValue),
+        ]
+
+        // Calculate job execution time
+        Timer(
+            label: "\(Self.metricsLabel).duration",
+            dimensions: dimensions,
+            preferredDisplayUnit: .seconds
+        ).recordNanoseconds(DispatchTime.now().uptimeNanoseconds - startTime)
+
+        // Increment job counter base on status
+        Counter(
+            label: Self.metricsLabel,
+            dimensions: dimensions
+        ).increment()
+    }
+}

--- a/Sources/Jobs/JobMetricsHelper.swift
+++ b/Sources/Jobs/JobMetricsHelper.swift
@@ -36,6 +36,7 @@ internal enum JobMetricsHelper {
     /// Update job metrics
     /// - Parameters:
     ///   - name: String Job name
+    ///   - jobID: String is only used for the completed meter
     ///   - startTime: UInt64 when the job started
     ///   - error: Error? job error
     ///   - retrying: Bool if the job is being retried

--- a/Sources/Jobs/JobParameters.swift
+++ b/Sources/Jobs/JobParameters.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Metrics
+
 /// Defines job parameters and identifier
 public protocol JobParameters: Codable, Sendable {
     /// Job type name
@@ -26,7 +28,13 @@ extension JobParameters {
 
     /// Added so it is possible to push JobParameters referenced as Existentials to a Job queue
     @discardableResult public func push<Queue: JobQueueDriver>(to jobQueue: JobQueue<Queue>, options: JobOptions = .init()) async throws -> Queue.JobID {
-        try await jobQueue.push(self, options: options)
+        let jobId = try await jobQueue.push(self, options: options)
+        // Scheduled jobs never increment the queued meter.
+        Meter(label: JobMetricsHelper.meterLabel, dimensions: [
+            ("status", JobMetricsHelper.JobStatus.queued.rawValue),
+            ("name", type(of: self).jobName),
+        ]).increment()
+        return jobId
     }
 }
 

--- a/Sources/Jobs/JobParameters.swift
+++ b/Sources/Jobs/JobParameters.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Metrics
-
 /// Defines job parameters and identifier
 public protocol JobParameters: Codable, Sendable {
     /// Job type name
@@ -28,13 +26,7 @@ extension JobParameters {
 
     /// Added so it is possible to push JobParameters referenced as Existentials to a Job queue
     @discardableResult public func push<Queue: JobQueueDriver>(to jobQueue: JobQueue<Queue>, options: JobOptions = .init()) async throws -> Queue.JobID {
-        let jobId = try await jobQueue.push(self, options: options)
-        // Scheduled jobs never increment the queued meter.
-        Meter(label: JobMetricsHelper.meterLabel, dimensions: [
-            ("status", JobMetricsHelper.JobStatus.queued.rawValue),
-            ("name", type(of: self).jobName),
-        ]).increment()
-        return jobId
+        return try await jobQueue.push(self, options: options)
     }
 }
 

--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -50,7 +50,10 @@ public struct JobQueue<Queue: JobQueueDriver>: Service {
         let buffer = try self.queue.encode(id: id, parameters: parameters)
         let jobName = id.name
         let id = try await self.queue.push(buffer, options: options)
-        Meter(label: "swift.jobs.meter", dimensions: [("status", "queued"), ("name", jobName)]).increment()
+        Meter(label: JobMetricsHelper.meterLabel, dimensions: [
+            ("status", JobMetricsHelper.JobStatus.queued.rawValue),
+            ("name", jobName),
+        ]).increment()
         self.logger.debug(
             "Pushed Job",
             metadata: ["JobID": .stringConvertible(id), "JobName": .string(jobName)]

--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -52,7 +52,6 @@ public struct JobQueue<Queue: JobQueueDriver>: Service {
         let id = try await self.queue.push(buffer, options: options)
         Meter(label: JobMetricsHelper.meterLabel, dimensions: [
             ("status", JobMetricsHelper.JobStatus.queued.rawValue),
-            ("name", jobName),
         ]).increment()
         self.logger.debug(
             "Pushed Job",

--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -52,6 +52,7 @@ public struct JobQueue<Queue: JobQueueDriver>: Service {
         let id = try await self.queue.push(buffer, options: options)
         Meter(label: JobMetricsHelper.meterLabel, dimensions: [
             ("status", JobMetricsHelper.JobStatus.queued.rawValue),
+            ("jobID", id.description),
         ]).increment()
         self.logger.debug(
             "Pushed Job",

--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -48,9 +48,9 @@ public struct JobQueue<Queue: JobQueueDriver>: Service {
         options: JobOptions = .init()
     ) async throws -> Queue.JobID {
         let buffer = try self.queue.encode(id: id, parameters: parameters)
-        Meter(label: "swift.jobs.meter", dimensions: [("status", "queued")]).increment()
         let jobName = id.name
         let id = try await self.queue.push(buffer, options: options)
+        Meter(label: "swift.jobs.meter", dimensions: [("status", "queued"), ("name", jobName)]).increment()
         self.logger.debug(
             "Pushed Job",
             metadata: ["JobID": .stringConvertible(id), "JobName": .string(jobName)]

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -191,6 +191,8 @@ extension JobQueueHandler: CustomStringConvertible {
                 label: self.metricsLabel,
                 dimensions: [("name", name), ("status", JobStatus.retried.rawValue)]
             ).increment()
+            // increment queued meter else we will get negative values
+            Meter(label: self.meterLabel, dimensions: [("status", "queued"), ("name", name)]).increment()
             return
         }
 

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -101,7 +101,6 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
 
         do {
             do {
-                Meter(label: self.meterLabel, dimensions: [("status", JobStatus.processing.rawValue)]).increment()
                 try await job.execute(context: .init(logger: logger))
             } catch let error as CancellationError {
                 logger.debug("Job cancelled")

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -89,12 +89,6 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
             return
         }
         logger[metadataKey: "JobName"] = .string(job.name)
-        
-        defer {
-            Meter(label: JobMetricsHelper.meterLabel, dimensions: [
-                ("status", JobMetricsHelper.JobStatus.processing.rawValue),
-            ]).decrement()
-        }
 
         // Calculate wait time from queued to processing
         let jobQueuedDuration = Date.now.timeIntervalSince(job.queuedAt)
@@ -103,18 +97,18 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
             dimensions: [("name", job.name)],
             preferredDisplayUnit: .seconds
         ).recordSeconds(jobQueuedDuration)
-        
+
         // Decrement the current job by 1
         Meter(label: JobMetricsHelper.meterLabel, dimensions: [
             ("status", JobMetricsHelper.JobStatus.queued.rawValue),
-            ("name", job.name)
+            ("name", job.name),
         ]).decrement()
 
         logger.debug("Starting Job")
         // Processing start here
         Meter(label: JobMetricsHelper.meterLabel, dimensions: [
             ("status", JobMetricsHelper.JobStatus.processing.rawValue),
-            ("name", job.name)
+            ("name", job.name),
         ]).increment()
 
         do {

--- a/Tests/JobsTests/MetricsTests.swift
+++ b/Tests/JobsTests/MetricsTests.swift
@@ -311,6 +311,12 @@ final class MetricsTests: XCTestCase {
 
         let queuedMeter = try XCTUnwrap(Self.testMetrics.meters.withLockedValue { $0 }["swift.jobs.meter"] as? TestMeter)
         XCTAssertEqual(queuedMeter.values.withLockedValue { $0 }.count, 1)
+
+        let processingMeter = try XCTUnwrap(Self.testMetrics.meters.withLockedValue { $0 }["swift.jobs.meter"] as? TestMeter)
+        XCTAssertEqual(processingMeter.values.withLockedValue { $0 }.count, 1)
+        XCTAssertEqual(processingMeter.dimensions.count, 1)
+        XCTAssertEqual(processingMeter.dimensions[0].0, "status")
+        XCTAssertEqual(processingMeter.dimensions[0].1, "processing")
     }
 
     func testFailedJobs() async throws {

--- a/Tests/JobsTests/MetricsTests.swift
+++ b/Tests/JobsTests/MetricsTests.swift
@@ -317,9 +317,6 @@ final class MetricsTests: XCTestCase {
         XCTAssertEqual(processingMeter.dimensions.count, 1)
         XCTAssertEqual(processingMeter.dimensions[0].0, "status")
         XCTAssertEqual(processingMeter.dimensions[0].1, "processing")
-
-        let workerCountMeter = try XCTUnwrap(Self.testMetrics.meters.withLockedValue { $0 }["swift.jobs.worker.count"] as? TestMeter)
-        XCTAssertEqual(workerCountMeter.values.withLockedValue { $0 }.count, 1)
     }
 
     func testFailToDecode() async throws {
@@ -374,12 +371,6 @@ final class MetricsTests: XCTestCase {
             }
 
             expectation.fulfill()
-
-            let meter = try XCTUnwrap(Self.testMetrics.meters.withLockedValue { $0 }["swift.jobs.meter"] as? TestMeter)
-            XCTAssertEqual(meter.values.withLockedValue { $0 }.count, 1)
-            XCTAssertEqual(meter.values.withLockedValue { $0 }[0].1, 0)
-            XCTAssertEqual(meter.dimensions[0].0, "status")
-            XCTAssertEqual(meter.dimensions[0].1, "queued")
 
             if (currentJobTryCount.withLockedValue { $0 }) == 0 {
                 throw FailedError()

--- a/Tests/JobsTests/MetricsTests.swift
+++ b/Tests/JobsTests/MetricsTests.swift
@@ -314,7 +314,7 @@ final class MetricsTests: XCTestCase {
 
         let processingMeter = try XCTUnwrap(Self.testMetrics.meters.withLockedValue { $0 }["swift.jobs.meter"] as? TestMeter)
         XCTAssertEqual(processingMeter.values.withLockedValue { $0 }.count, 1)
-        XCTAssertEqual(processingMeter.dimensions.count, 1)
+        XCTAssertEqual(processingMeter.dimensions.count, 2)
         XCTAssertEqual(processingMeter.dimensions[0].0, "status")
         XCTAssertEqual(processingMeter.dimensions[0].1, "processing")
     }


### PR DESCRIPTION
This PR is for the followings:

1 -  fixed an issue where the queued meter would become negative during retries
~~2 - added number of workers to job metrics~~
     processing count can give the same metric
3 - added discarded jobs metrics

With the most recent commit:

Once can get prometheus UI or Grafana to update queue in realtime with the following query

```promql
count(swift_jobs_meter{status="queued"} unless on(jobID) (swift_jobs_meter{status="processing"})) or vector(0)
```