### PR TITLE
Remove job id from metrics

### DIFF
--- a/Sources/Jobs/JobMetricsHelper.swift
+++ b/Sources/Jobs/JobMetricsHelper.swift
@@ -36,14 +36,12 @@ internal enum JobMetricsHelper {
     /// Update job metrics
     /// - Parameters:
     ///   - name: String Job name
-    ///   - jobID: String is only used for the completed meter
     ///   - startTime: UInt64 when the job started
     ///   - error: Error? job error
     ///   - retrying: Bool if the job is being retried
     ///
     static func updateMetrics(
         for name: String,
-        jobID: String,
         startTime: UInt64,
         error: Error? = nil,
         retrying: Bool = false
@@ -56,8 +54,7 @@ internal enum JobMetricsHelper {
         Meter(
             label: JobMetricsHelper.meterLabel,
             dimensions: [
-                ("status", JobMetricsHelper.JobStatus.completed.rawValue),
-                ("jobID", jobID),
+                ("status", JobMetricsHelper.JobStatus.completed.rawValue)
             ]
         ).increment()
 

--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -53,8 +53,7 @@ public struct JobQueue<Queue: JobQueueDriver>: Service {
         Meter(
             label: JobMetricsHelper.meterLabel,
             dimensions: [
-                ("status", JobMetricsHelper.JobStatus.queued.rawValue),
-                ("jobID", id.description),
+                ("status", JobMetricsHelper.JobStatus.queued.rawValue)
             ]
         ).increment()
         self.logger.debug(

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -72,16 +72,14 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
         Meter(
             label: JobMetricsHelper.meterLabel,
             dimensions: [
-                ("status", JobMetricsHelper.JobStatus.queued.rawValue),
-                ("jobID", queuedJob.id.description),
+                ("status", JobMetricsHelper.JobStatus.queued.rawValue)
             ]
         ).decrement()
 
         Meter(
             label: JobMetricsHelper.meterLabel,
             dimensions: [
-                ("status", JobMetricsHelper.JobStatus.processing.rawValue),
-                ("jobID", queuedJob.id.description),
+                ("status", JobMetricsHelper.JobStatus.processing.rawValue)
             ]
         ).increment()
 
@@ -89,8 +87,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
             Meter(
                 label: JobMetricsHelper.meterLabel,
                 dimensions: [
-                    ("status", JobMetricsHelper.JobStatus.processing.rawValue),
-                    ("jobID", queuedJob.id.description),
+                    ("status", JobMetricsHelper.JobStatus.processing.rawValue)
                 ]
             ).decrement()
         }
@@ -104,8 +101,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
             Meter(
                 label: JobMetricsHelper.discardedMeter,
                 dimensions: [
-                    ("reason", "INVALID_JOB_ID"),
-                    ("jobID", queuedJob.id.description),
+                    ("reason", "INVALID_JOB_ID")
                 ]
             ).increment()
             return
@@ -115,8 +111,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
             Meter(
                 label: JobMetricsHelper.discardedMeter,
                 dimensions: [
-                    ("reason", "DECODE_FAILED"),
-                    ("jobID", queuedJob.id.description),
+                    ("reason", "DECODE_FAILED")
                 ]
             ).increment()
             return
@@ -144,7 +139,6 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                 try await self.queue.failed(jobId: queuedJob.id, error: error)
                 JobMetricsHelper.updateMetrics(
                     for: job.name,
-                    jobID: queuedJob.id.description,
                     startTime: startTime,
                     error: error
                 )
@@ -155,7 +149,6 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                     try await self.queue.failed(jobId: queuedJob.id, error: error)
                     JobMetricsHelper.updateMetrics(
                         for: job.name,
-                        jobID: queuedJob.id.description,
                         startTime: startTime,
                         error: error
                     )
@@ -181,20 +174,20 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                 Meter(
                     label: JobMetricsHelper.meterLabel,
                     dimensions: [
-                        ("status", JobMetricsHelper.JobStatus.queued.rawValue),
-                        ("jobID", newJobId.description),
+                        ("status", JobMetricsHelper.JobStatus.queued.rawValue)
                     ]
                 ).increment()
 
                 JobMetricsHelper.updateMetrics(
                     for: job.name,
-                    jobID: queuedJob.id.description,
                     startTime: startTime,
                     retrying: true
                 )
                 logger.debug(
                     "Retrying Job",
                     metadata: [
+                        "JobID": .stringConvertible(newJobId),
+                        "JobName": .string(job.name),
                         "attempts": .stringConvertible(attempts),
                         "delayedUntil": .stringConvertible(delay),
                     ]
@@ -203,10 +196,10 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
             }
             logger.debug("Finished Job")
             try await self.queue.finished(jobId: queuedJob.id)
-            JobMetricsHelper.updateMetrics(for: job.name, jobID: queuedJob.id.description, startTime: startTime)
+            JobMetricsHelper.updateMetrics(for: job.name, startTime: startTime)
         } catch {
             logger.debug("Failed to set job status")
-            JobMetricsHelper.updateMetrics(for: job.name, jobID: queuedJob.id.description, startTime: startTime, error: error)
+            JobMetricsHelper.updateMetrics(for: job.name, startTime: startTime, error: error)
         }
     }
 

--- a/Tests/JobsTests/MetricsTests.swift
+++ b/Tests/JobsTests/MetricsTests.swift
@@ -319,7 +319,7 @@ final class MetricsTests: XCTestCase {
 
         let processingMeter = try XCTUnwrap(Self.testMetrics.meters.withLockedValue { $0 }["swift.jobs.meter"] as? TestMeter)
         XCTAssertEqual(processingMeter.values.withLockedValue { $0 }.count, 1)
-        XCTAssertEqual(processingMeter.dimensions.count, 2)
+        XCTAssertEqual(processingMeter.dimensions.count, 1)
         XCTAssertEqual(processingMeter.dimensions[0].0, "status")
         XCTAssertEqual(processingMeter.dimensions[0].1, "processing")
     }
@@ -347,7 +347,7 @@ final class MetricsTests: XCTestCase {
         }
 
         let queuedMeter = try XCTUnwrap(Self.testMetrics.meters.withLockedValue { $0 }["swift.jobs.discarded"] as? TestMeter)
-        XCTAssertEqual(queuedMeter.dimensions.count, 2)
+        XCTAssertEqual(queuedMeter.dimensions.count, 1)
         XCTAssertEqual(queuedMeter.dimensions[0].0, "reason")
         XCTAssertEqual(queuedMeter.dimensions[0].1, "DECODE_FAILED")
     }


### PR DESCRIPTION
It generates a unique metric for each job instance 