### PR TITLE
Add Tracing to job queue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
@@ -24,6 +25,7 @@ let package = Package(
             name: "Jobs",
             dependencies: [
                 .product(name: "Collections", package: "swift-collections"),
+                .product(name: "Tracing", package: "swift-distributed-tracing"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),

--- a/Sources/Jobs/EncodableJob.swift
+++ b/Sources/Jobs/EncodableJob.swift
@@ -19,7 +19,13 @@ struct EncodableJob<Parameters: Codable & Sendable>: Encodable, Sendable {
     let id: JobIdentifier<Parameters>
     let data: JobInstanceData<Parameters>
 
-    init(id: JobIdentifier<Parameters>, parameters: Parameters, queuedAt: Date, attempts: Int) {
+    init(
+        id: JobIdentifier<Parameters>,
+        parameters: Parameters,
+        queuedAt: Date,
+        attempts: Int
+    ) {
+
         self.id = id
         self.data = .init(parameters: parameters, queuedAt: queuedAt, attempts: attempts)
     }


### PR DESCRIPTION
The trace context of the current span is stored in the job metadata and then added as a link to the job span. This means you get a link to the span that triggered the job which could either be the original http request, or the previously failed attempt. 