### PR TITLE
Keep existing job id on retry

### DIFF
--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -30,13 +30,13 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == QueuedJ
     ///   - options: JobOptions
     /// - Returns: Identifier of queued jobs
     func push(_ buffer: ByteBuffer, options: JobOptions) async throws -> JobID
-    /// Update existing Job onto queue
+    /// Retry an existing Job
     /// - Parameters
     ///   - id JobID
     ///   - buffer: ByteBuffer
     ///   - options: JobOptions
     /// - Returns: Bool
-    @discardableResult func update(_ id: JobID, buffer: ByteBuffer, options: JobOptions) async throws -> Bool
+    @discardableResult func retry(_ id: JobID, buffer: ByteBuffer, options: JobOptions) async throws -> Bool
     /// This is called to say job has finished processing and it can be deleted
     func finished(jobId: JobID) async throws
     /// This is called to say job has failed to run and should be put aside

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -30,6 +30,13 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == QueuedJ
     ///   - options: JobOptions
     /// - Returns: Identifier of queued jobs
     func push(_ buffer: ByteBuffer, options: JobOptions) async throws -> JobID
+    /// Update existing Job onto queue
+    /// - Parameters
+    ///   - id JobID
+    ///   - buffer: ByteBuffer
+    ///   - options: JobOptions
+    /// - Returns: Bool
+    @discardableResult func update(_ id: JobID, buffer: ByteBuffer, options: JobOptions) async throws -> Bool
     /// This is called to say job has finished processing and it can be deleted
     func finished(jobId: JobID) async throws
     /// This is called to say job has failed to run and should be put aside

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -117,7 +117,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                 // function.
                 try await Task {
                     try await self.queue.failed(jobId: queuedJob.id, error: error)
-                }.get()
+                }.value
                 return
             } catch {
                 if job.didFail {

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -131,7 +131,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                 let delay = self.calculateBackoff(attempts: attempts)
 
                 /// update the current job
-                try await self.queue.update(
+                try await self.queue.retry(
                     queuedJob.id,
                     buffer: self.queue.encode(job, attempts: attempts),
                     options: .init(

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -129,12 +129,11 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                 let attempts = (job.attempts ?? 0) + 1
 
                 let delay = self.calculateBackoff(attempts: attempts)
-
-                // remove from processing lists
-                try await self.queue.finished(jobId: queuedJob.id)
-                // push new job in the queue
-                let newJobId = try await self.queue.push(
-                    self.queue.encode(job, attempts: attempts),
+                
+                /// update the current job
+                try await self.queue.update(
+                    queuedJob.id,
+                    buffer: self.queue.encode(job, attempts: attempts),
                     options: .init(
                         delayUntil: delay
                     )
@@ -143,7 +142,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                 logger.debug(
                     "Retrying Job",
                     metadata: [
-                        "JobID": .stringConvertible(newJobId),
+                        "JobID": .stringConvertible(queuedJob.id),
                         "JobName": .string(job.name),
                         "attempts": .stringConvertible(attempts),
                         "delayedUntil": .stringConvertible(delay),

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -129,7 +129,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                 let attempts = (job.attempts ?? 0) + 1
 
                 let delay = self.calculateBackoff(attempts: attempts)
-                
+
                 /// update the current job
                 try await self.queue.update(
                     queuedJob.id,

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -50,14 +50,14 @@ public final class MemoryQueue: JobQueueDriver {
         try await self.queue.push(buffer, options: options)
     }
 
-    /// Update an existing job in the  queue
+    /// Retry an existing job
     /// - Parameters:
     ///   - id: Job ID
     ///   - buffer: buffer containing job data
     ///   - options: Job options
     /// - Returns: Bool
-    @discardableResult public func update(_ id: JobID, buffer: ByteBuffer, options: JobOptions) async throws -> Bool {
-        try await self.queue.update(id, buffer: buffer, options: options)
+    @discardableResult public func retry(_ id: JobID, buffer: ByteBuffer, options: JobOptions) async throws -> Bool {
+        try await self.queue.retry(id, buffer: buffer, options: options)
     }
 
     public func finished(jobId: JobID) async throws {
@@ -98,7 +98,7 @@ public final class MemoryQueue: JobQueueDriver {
             return id
         }
 
-        func update(_ id: JobID, buffer: ByteBuffer, options: JobOptions) throws -> Bool {
+        func retry(_ id: JobID, buffer: ByteBuffer, options: JobOptions) throws -> Bool {
             self.clearPendingJob(jobId: id)
             let _ = self.queue.append((job: QueuedJob(id: id, jobBuffer: buffer), options: options))
             return true

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -49,6 +49,16 @@ public final class MemoryQueue: JobQueueDriver {
     @discardableResult public func push(_ buffer: ByteBuffer, options: JobOptions) async throws -> JobID {
         try await self.queue.push(buffer, options: options)
     }
+    
+    /// Update an existing job in the  queue
+    /// - Parameters:
+    ///   - id: Job ID
+    ///   - buffer: buffer containing job data
+    ///   - options: Job options
+    /// - Returns: Bool
+    @discardableResult public func update(_ id: JobID, buffer: ByteBuffer, options: JobOptions) async throws -> Bool {
+        try await self.queue.update(id, buffer: buffer, options: options)
+    }
 
     public func finished(jobId: JobID) async throws {
         await self.queue.clearPendingJob(jobId: jobId)
@@ -86,6 +96,12 @@ public final class MemoryQueue: JobQueueDriver {
             let id = JobID()
             self.queue.append((job: QueuedJob(id: id, jobBuffer: jobBuffer), options: options))
             return id
+        }
+        
+        func update(_ id: JobID, buffer: ByteBuffer, options: JobOptions) throws -> Bool {
+            self.clearPendingJob(jobId: id)
+            let _ = self.queue.append((job: QueuedJob(id: id, jobBuffer: buffer), options: options))
+            return true
         }
 
         func clearPendingJob(jobId: JobID) {

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -49,7 +49,7 @@ public final class MemoryQueue: JobQueueDriver {
     @discardableResult public func push(_ buffer: ByteBuffer, options: JobOptions) async throws -> JobID {
         try await self.queue.push(buffer, options: options)
     }
-    
+
     /// Update an existing job in the  queue
     /// - Parameters:
     ///   - id: Job ID
@@ -97,7 +97,7 @@ public final class MemoryQueue: JobQueueDriver {
             self.queue.append((job: QueuedJob(id: id, jobBuffer: jobBuffer), options: options))
             return id
         }
-        
+
         func update(_ id: JobID, buffer: ByteBuffer, options: JobOptions) throws -> Bool {
             self.clearPendingJob(jobId: id)
             let _ = self.queue.append((job: QueuedJob(id: id, jobBuffer: buffer), options: options))


### PR DESCRIPTION
* Fixed an issue where a new job id was created on retry
* Replaced Task.get with Task.value as the former has been deprecated
* Added new func update to job queue

This PR closes #58 

Will follow up with the drivers changes