### PR TITLE
Make a job’s queued at date available to its job context

### DIFF
--- a/Sources/Jobs/JobContext.swift
+++ b/Sources/Jobs/JobContext.swift
@@ -14,10 +14,15 @@
 
 import Logging
 
+import struct Foundation.Date
+
 /// Context of running job
 public struct JobContext {
     /// Job instance identifier
     public let jobInstanceID: String
     /// Logger
     public let logger: Logger
+    /// The date when the job was scheduled
+    /// to run or queued
+    public let queuedAt: Date
 }

--- a/Sources/Jobs/JobParameters.swift
+++ b/Sources/Jobs/JobParameters.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import struct Foundation.Date
+
 /// Defines job parameters and identifier
 public protocol JobParameters: Codable, Sendable {
     /// Job type name

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -90,7 +90,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
         logger.debug("Starting Job")
         do {
             do {
-                let context = JobContext(jobInstanceID: jobID.description, logger: logger)
+                let context = JobContext(jobInstanceID: jobID.description, logger: logger, queuedAt: job.queuedAt)
                 try await self.middleware.handleJob(job: job, context: context) { job, context in
                     try await job.execute(context: context)
                 }

--- a/Tests/JobsTests/JobMiddlewareTests.swift
+++ b/Tests/JobsTests/JobMiddlewareTests.swift
@@ -78,7 +78,8 @@ final class JobMiddlewareTests: XCTestCase {
         await observers.onPopJob(result: .success(FakeJobInstance()), jobInstanceID: "0")
         XCTAssertEqual(observer1.popped, true)
         XCTAssertEqual(observer2.popped, true)
-        try await observers.handleJob(job: FakeJobInstance(), context: .init(jobInstanceID: "0", logger: .init(label: "Test"))) { _, _ in }
+        let job = FakeJobInstance()
+        try await observers.handleJob(job: job, context: .init(jobInstanceID: "0", logger: .init(label: "Test"), queuedAt: job.queuedAt)) { _, _ in }
         XCTAssertEqual(observer1.handled, true)
         XCTAssertEqual(observer2.handled, true)
     }
@@ -110,7 +111,8 @@ final class JobMiddlewareTests: XCTestCase {
             XCTAssertEqual(middleware1.pushed, first == true)
             await middlewareChain.onPopJob(result: .success(FakeJobInstance()), jobInstanceID: "0")
             XCTAssertEqual(middleware1.popped, first == true)
-            try await middlewareChain.handleJob(job: FakeJobInstance(), context: .init(jobInstanceID: "0", logger: .init(label: "Test"))) { _, _ in }
+            let job = FakeJobInstance()
+            try await middlewareChain.handleJob(job: job, context: .init(jobInstanceID: "0", logger: .init(label: "Test"), queuedAt: job.queuedAt)) { _, _ in }
             XCTAssertEqual(middleware1.handled, first == true)
         }
         try await testIf(true)
@@ -149,7 +151,8 @@ final class JobMiddlewareTests: XCTestCase {
             await middlewareChain.onPopJob(result: .success(FakeJobInstance()), jobInstanceID: "0")
             XCTAssertEqual(middleware1.popped, first == true)
             XCTAssertEqual(middleware2.popped, first != true)
-            try await middlewareChain.handleJob(job: FakeJobInstance(), context: .init(jobInstanceID: "0", logger: .init(label: "Test"))) { _, _ in }
+            let job = FakeJobInstance()
+            try await middlewareChain.handleJob(job: job, context: .init(jobInstanceID: "0", logger: .init(label: "Test"), queuedAt: job.queuedAt)) { _, _ in }
             XCTAssertEqual(middleware1.handled, first == true)
             XCTAssertEqual(middleware2.handled, first != true)
         }

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -174,6 +174,7 @@ final class JobsTests: XCTestCase {
         let delayedJobParameters = TestParameters(value: 23)
         let notDelayedJobParameters = TestParameters(value: 89)
         let jobExecutionSequence: NIOLockedValueBox<[TestParameters]> = .init([])
+        let delayedJobQueuedAt: NIOLockedValueBox<Date> = .init(Date.now)
         jobQueue.registerJob(parameters: TestParameters.self) { parameters, context in
             context.logger.info("Parameters=\(parameters)")
             jobExecutionSequence.withLockedValue {
@@ -183,6 +184,9 @@ final class JobsTests: XCTestCase {
 
             if parameters == delayedJobParameters {
                 delayedJob.wrappingDecrement(by: 1, ordering: .relaxed)
+                delayedJobQueuedAt.withLockedValue {
+                    $0 = context.queuedAt
+                }
             }
         }
         try await testJobQueue(jobQueue) {
@@ -195,6 +199,7 @@ final class JobsTests: XCTestCase {
         }
 
         XCTAssertEqual(jobExecutionSequence.withLockedValue { $0 }, [notDelayedJobParameters, delayedJobParameters])
+        XCTAssertGreaterThan(Date.now, delayedJobQueuedAt.withLockedValue { $0 })
     }
 
     func testJobParameters() async throws {


### PR DESCRIPTION
This PR enables downstream access to when a job was queued. It affords a user to either skip the current run or process the job. This is very useful for scheduled jobs.