### PR TITLE
crontab schedule

### DIFF
--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -29,7 +29,7 @@ public protocol JobQueueProtocol: Service {
     ///   - id: Job identifier
     ///   - parameters: parameters for the job
     /// - Returns: Identifier of queued job
-    func push<Parameters: JobParameters>(
+    @discardableResult func push<Parameters: JobParameters>(
         _ parameters: Parameters,
         options: JobOptions
     ) async throws -> Queue.JobID

--- a/Sources/Jobs/Scheduler/Schedule+crontab.swift
+++ b/Sources/Jobs/Scheduler/Schedule+crontab.swift
@@ -21,6 +21,11 @@ import Foundation
 #endif
 
 extension Schedule {
+    ///  Initialize Scehdule using crontab style string
+    /// - Parameters:
+    ///   - crontab: Crontab string
+    ///   - timeZone: Timezone to run schedule in
+    /// - Throws: ScheduleError for corrupt crontabs and crontabs we don't suppoty
     init(crontab: String, timeZone: TimeZone = .current) throws {
         let values = crontab.split(separator: " ", omittingEmptySubsequences: true)
         guard values.count == 5 else { throw ScheduleError("Crontab string requires 5 values") }

--- a/Sources/Jobs/Scheduler/Schedule+crontab.swift
+++ b/Sources/Jobs/Scheduler/Schedule+crontab.swift
@@ -36,7 +36,7 @@ extension Schedule {
             guard let month = Month(rawValue: $0) else { throw ScheduleError("Invalid month value") }
             return month
         }
-        let day = try Self.parse(values[4], range: 0...6) {
+        let weekDay = try Self.parse(values[4], range: 0...6) {
             guard let day = Day(rawValue: $0 + 1) else {
                 if $0 == 7 {
                     return Day.sunday
@@ -45,7 +45,7 @@ extension Schedule {
             }
             return day
         }
-        let schedule = Self(second: .specific(0), minute: minutes, hour: hours, date: date, month: month, day: day, timeZone: timeZone)
+        let schedule = Self(second: .specific(0), minute: minutes, hour: hours, date: date, month: month, day: weekDay, timeZone: timeZone)
 
         // if we have a selection set for either day or date we don't support setting the other value
         switch (schedule.day, schedule.date) {
@@ -115,7 +115,7 @@ extension Schedule {
             return .init(array)
         } else if let values = try? everyRegex.wholeMatch(in: entry) {
             let numberOfValues = (range.count + 1) / values.1
-            let array = try (0..<numberOfValues).map { try transform($0 * values.1) }
+            let array = try (0..<numberOfValues).map { try transform(range.lowerBound + $0 * values.1) }
             return .init(array)
         } else if let values = try? selectionRegex.wholeMatch(in: entry) {
             let array = try values.1.map { try transform($0) }

--- a/Sources/Jobs/Scheduler/Schedule+crontab.swift
+++ b/Sources/Jobs/Scheduler/Schedule+crontab.swift
@@ -41,6 +41,16 @@ extension Schedule {
             return day
         }
         self.init(second: .specific(0), minute: minutes, hour: hours, date: date, month: month, day: day, timeZone: timeZone)
+
+        // if we have a selection set for either day or date we don't support setting the other value
+        switch (self.day, self.date) {
+        case (.selection, .specific), (.selection, .selection), (.specific, .selection):
+            throw ScheduleError(
+                "Schedule does not support a combination of date and weekday where one is a selection of values and the other is not the wildcard '*'"
+            )
+        default:
+            break
+        }
     }
 
     static func parse<Value>(_ entry: Substring, range: ClosedRange<Int>, transform: (Int) throws -> Value) throws -> Parameter<Value> {

--- a/Sources/Jobs/Scheduler/Schedule+crontab.swift
+++ b/Sources/Jobs/Scheduler/Schedule+crontab.swift
@@ -27,6 +27,10 @@ extension Schedule {
     ///   - timeZone: Timezone to run schedule in
     /// - Throws: ScheduleError for corrupt crontabs and crontabs we don't suppoty
     static func crontab(_ crontab: String, timeZone: TimeZone = .current) throws -> Self {
+        if crontab.first == "@" {
+            guard let crontab = Self.crontabNicknames[crontab] else { throw ScheduleError("Unrecognised crontab nick name \(crontab)") }
+            return try Self.crontab(crontab, timeZone: timeZone)
+        }
         let values = crontab.split(separator: " ", omittingEmptySubsequences: true)
         guard values.count == 5 else { throw ScheduleError("Crontab string requires 5 values") }
         let minutes = try Self.parse(values[0], range: 0...59, count: 60)
@@ -157,6 +161,15 @@ extension Schedule {
         }
     }
 
+    private static let crontabNicknames: [String: String] = [
+        "@yearly": "0 0 1 1 *",
+        "@annually": "0 0 1 1 *",
+        "@monthly": "0 0 1 * *",
+        "@weekly": "0 0 * * 0",
+        "@daily": "0 0 * * *",
+        "@hourly": "0 * * * *",
+    ]
+
     private static let dayNameNumberMap: [Substring: Int] = [
         "sun": 0,
         "mon": 1,
@@ -181,43 +194,4 @@ extension Schedule {
         "nov": 11,
         "dec": 12,
     ]
-}
-
-protocol ExpressibleByRegexName {
-    init?<S: StringProtocol>(regexName: S)
-}
-
-extension Schedule.Day: ExpressibleByRegexName {
-    init?<S: StringProtocol>(regexName: S) {
-        switch regexName {
-        case "sun": self = .sunday
-        case "mon": self = .monday
-        case "tue": self = .tuesday
-        case "wed": self = .wednesday
-        case "thu": self = .thursday
-        case "fri": self = .friday
-        case "sat": self = .saturday
-        default: return nil
-        }
-    }
-}
-
-extension Schedule.Month: ExpressibleByRegexName {
-    init?<S: StringProtocol>(regexName: S) {
-        switch regexName {
-        case "jan": self = .january
-        case "feb": self = .february
-        case "mar": self = .march
-        case "apr": self = .april
-        case "may": self = .may
-        case "jun": self = .june
-        case "jul": self = .july
-        case "aug": self = .august
-        case "sep": self = .september
-        case "oct": self = .october
-        case "nov": self = .november
-        case "dec": self = .december
-        default: return nil
-        }
-    }
 }

--- a/Sources/Jobs/Scheduler/Schedule+crontab.swift
+++ b/Sources/Jobs/Scheduler/Schedule+crontab.swift
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2025 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import RegexBuilder
+
+#if os(Linux)
+@preconcurrency import Foundation
+#else
+import Foundation
+#endif
+
+extension Schedule {
+    init(crontab: String, timeZone: TimeZone = .current) throws {
+        let values = crontab.split(separator: " ", omittingEmptySubsequences: true)
+        guard values.count == 5 else { throw ScheduleError("Crontab string requires 5 values") }
+        let minutes = try Self.parse(values[0], range: 0...60) { $0 }
+        let hours = try Self.parse(values[1], range: 0...24) { $0 }
+        let date = try Self.parse(values[2], range: 0...31) { $0 }
+        let month = try Self.parse(values[3], range: 1...12) {
+            guard let month = Month(rawValue: $0) else { throw ScheduleError("Invalid month value") }
+            return month
+        }
+        let day = try Self.parse(values[4], range: 0...6) {
+            guard let day = Day(rawValue: $0 + 1) else {
+                if $0 == 7 {
+                    return Day.sunday
+                }
+                throw ScheduleError("Invalid day value")
+            }
+            return day
+        }
+        self.init(second: .specific(0), minute: minutes, hour: hours, date: date, month: month, day: day, timeZone: timeZone)
+    }
+
+    static func parse<Value>(_ entry: Substring, range: ClosedRange<Int>, transform: (Int) throws -> Value) throws -> Parameter<Value> {
+        let numberRegex = Regex {
+            Anchor.startOfLine
+            Capture {
+                OneOrMore(.digit)
+            } transform: {
+                Int($0)!
+            }
+            Anchor.endOfLine
+        }
+        let rangeRegex = Regex {
+            Anchor.startOfLine
+            Capture {
+                OneOrMore(.digit)
+            } transform: {
+                Int($0)!
+            }
+            "-"
+            Capture {
+                OneOrMore(.digit)
+            } transform: {
+                Int($0)!
+            }
+            Anchor.endOfLine
+        }
+        let everyRegex = Regex {
+            Anchor.startOfLine
+            "*/"
+            Capture {
+                OneOrMore(.digit)
+            } transform: {
+                Int($0)!
+            }
+            Anchor.endOfLine
+        }
+        let selectionRegex: Regex = Regex {
+            Anchor.startOfLine
+            Capture {
+                OneOrMore {
+                    OneOrMore(.digit)
+                    ","
+                }
+                OneOrMore(.digit)
+            } transform: {
+                $0.split(separator: ",").map { Int($0)! }
+            }
+            Anchor.endOfLine
+        }
+        if entry == "*" { return .any }
+        if let values = try? numberRegex.wholeMatch(in: entry) {
+            return try .init(transform(values.1))
+        } else if let values = try? rangeRegex.wholeMatch(in: entry) {
+            let array = try (values.1...values.2).map { try transform($0) }
+            return .init(array)
+        } else if let values = try? everyRegex.wholeMatch(in: entry) {
+            let numberOfValues = (range.count + 1) / values.1
+            let array = try (0..<numberOfValues).map { try transform($0 * values.1) }
+            return .init(array)
+        } else if let values = try? selectionRegex.wholeMatch(in: entry) {
+            let array = try values.1.map { try transform($0) }
+            return .init(array)
+        } else {
+            throw ScheduleError("Unrecognised crontab element \(entry)")
+        }
+    }
+}

--- a/Sources/Jobs/Scheduler/Schedule+crontab.swift
+++ b/Sources/Jobs/Scheduler/Schedule+crontab.swift
@@ -134,12 +134,14 @@ extension Schedule {
         if let values = try? numberRegex.wholeMatch(in: entry), let value = transform(values.1) {
             return .init(value)
         } else if let values = try? rangeRegex.wholeMatch(in: entry), let lower = transform(values.1), let upper = transform(values.2) {
+            guard lower < upper else { throw ScheduleError("Crontab range requires first value to be before the second: \(values.0)") }
             return .init(lower...upper)
         } else if let values = try? everyRegex.wholeMatch(in: entry) {
             let numberOfValues = (count + values.1 - 1) / values.1
             let array = (0..<numberOfValues).map { range.lowerBound + $0 * values.1 }
             return .init(array)
         } else if let values = try? everyInRangeRegex.wholeMatch(in: entry), let lower = transform(values.1), let upper = transform(values.2) {
+            guard lower < upper else { throw ScheduleError("Crontab range requires first value to be before the second: \(values.0)") }
             let range = lower...upper
             let numberOfValues = (range.count + values.3 - 1) / values.3
             let array = (0..<numberOfValues).map { range.lowerBound + $0 * values.3 }

--- a/Sources/Jobs/Scheduler/Schedule+crontab.swift
+++ b/Sources/Jobs/Scheduler/Schedule+crontab.swift
@@ -31,12 +31,12 @@ extension Schedule {
         guard values.count == 5 else { throw ScheduleError("Crontab string requires 5 values") }
         let minutes = try Self.parse(values[0], range: 0...59) { $0 }
         let hours = try Self.parse(values[1], range: 0...23) { $0 }
-        let date = try Self.parse(values[2], range: 1...31) { $0 }
+        let dayOfMonth = try Self.parse(values[2], range: 1...31) { $0 }
         let month = try Self.parse(values[3], range: 1...12) {
             guard let month = Month(rawValue: $0) else { throw ScheduleError("Invalid month value") }
             return month
         }
-        let weekDay = try Self.parse(values[4], range: 0...6) {
+        let dayOfWeek = try Self.parse(values[4], range: 0...6) {
             guard let day = Day(rawValue: $0 + 1) else {
                 if $0 == 7 {
                     return Day.sunday
@@ -45,7 +45,7 @@ extension Schedule {
             }
             return day
         }
-        let schedule = Self(second: .specific(0), minute: minutes, hour: hours, date: date, month: month, day: weekDay, timeZone: timeZone)
+        let schedule = Self(second: .specific(0), minute: minutes, hour: hours, date: dayOfMonth, month: month, day: dayOfWeek, timeZone: timeZone)
 
         // if we have a selection set for either day or date we don't support setting the other value
         switch (schedule.day, schedule.date) {

--- a/Sources/Jobs/Scheduler/Schedule+crontab.swift
+++ b/Sources/Jobs/Scheduler/Schedule+crontab.swift
@@ -21,12 +21,12 @@ import Foundation
 #endif
 
 extension Schedule {
-    ///  Initialize Scehdule using crontab style string
+    ///  Create Scehdule using crontab style string
     /// - Parameters:
     ///   - crontab: Crontab string
     ///   - timeZone: Timezone to run schedule in
     /// - Throws: ScheduleError for corrupt crontabs and crontabs we don't suppoty
-    init(crontab: String, timeZone: TimeZone = .current) throws {
+    static func crontab(_ crontab: String, timeZone: TimeZone = .current) throws -> Self {
         let values = crontab.split(separator: " ", omittingEmptySubsequences: true)
         guard values.count == 5 else { throw ScheduleError("Crontab string requires 5 values") }
         let minutes = try Self.parse(values[0], range: 0...60) { $0 }
@@ -45,10 +45,10 @@ extension Schedule {
             }
             return day
         }
-        self.init(second: .specific(0), minute: minutes, hour: hours, date: date, month: month, day: day, timeZone: timeZone)
+        let schedule = Self(second: .specific(0), minute: minutes, hour: hours, date: date, month: month, day: day, timeZone: timeZone)
 
         // if we have a selection set for either day or date we don't support setting the other value
-        switch (self.day, self.date) {
+        switch (schedule.day, schedule.date) {
         case (.selection, .specific), (.selection, .selection), (.specific, .selection):
             throw ScheduleError(
                 "Schedule does not support a combination of date and weekday where one is a selection of values and the other is not the wildcard '*'"
@@ -56,6 +56,7 @@ extension Schedule {
         default:
             break
         }
+        return schedule
     }
 
     static func parse<Value>(_ entry: Substring, range: ClosedRange<Int>, transform: (Int) throws -> Value) throws -> Parameter<Value> {

--- a/Sources/Jobs/Scheduler/Schedule+crontab.swift
+++ b/Sources/Jobs/Scheduler/Schedule+crontab.swift
@@ -29,14 +29,22 @@ extension Schedule {
     static func crontab(_ crontab: String, timeZone: TimeZone = .current) throws -> Self {
         let values = crontab.split(separator: " ", omittingEmptySubsequences: true)
         guard values.count == 5 else { throw ScheduleError("Crontab string requires 5 values") }
-        let minutes = try Self.parse(values[0], range: 0...59) { $0 }
-        let hours = try Self.parse(values[1], range: 0...23) { $0 }
-        let dayOfMonth = try Self.parse(values[2], range: 1...31) { $0 }
-        let month = try Self.parse(values[3], range: 1...12) {
+        let minutes = try Self.parse(values[0], range: 0...59, count: 60)
+        let hours = try Self.parse(values[1], range: 0...23, count: 24)
+        let dayOfMonth = try Self.parse(values[2], range: 1...31, count: 31)
+        let month = try Self.parse(values[3], range: 1...12, count: 12) {
+            if let month = Int($0) { return month }
+            if let month = Self.monthNameNumberMap[$0] { return month }
+            return nil
+        }.map {
             guard let month = Month(rawValue: $0) else { throw ScheduleError("Invalid month value") }
             return month
         }
-        let dayOfWeek = try Self.parse(values[4], range: 0...6) {
+        let dayOfWeek = try Self.parse(values[4], range: 0...7, count: 7) {
+            if let day = Int($0) { return day }
+            if let day = Self.dayNameNumberMap[$0] { return day }
+            return nil
+        }.map {
             guard let day = Day(rawValue: $0 + 1) else {
                 if $0 == 7 {
                     return Day.sunday
@@ -44,7 +52,8 @@ extension Schedule {
                 throw ScheduleError("Invalid day value")
             }
             return day
-        }
+        }.sorted()
+
         let schedule = Self(second: .specific(0), minute: minutes, hour: hours, date: dayOfMonth, month: month, day: dayOfWeek, timeZone: timeZone)
 
         // if we have a selection set for either day or date we don't support setting the other value
@@ -59,28 +68,27 @@ extension Schedule {
         return schedule
     }
 
-    static func parse<Value>(_ entry: Substring, range: ClosedRange<Int>, transform: (Int) throws -> Value) throws -> Parameter<Value> {
+    static func parse(
+        _ entry: Substring,
+        range: ClosedRange<Int>,
+        count: Int,
+        transform: (Substring) -> Int? = { Int($0) }
+    ) throws -> Parameter<Int> {
         let numberRegex = Regex {
             Anchor.startOfLine
             Capture {
-                OneOrMore(.digit)
-            } transform: {
-                Int($0)!
+                OneOrMore(.word)
             }
             Anchor.endOfLine
         }
         let rangeRegex = Regex {
             Anchor.startOfLine
             Capture {
-                OneOrMore(.digit)
-            } transform: {
-                Int($0)!
+                OneOrMore(.word)
             }
             "-"
             Capture {
-                OneOrMore(.digit)
-            } transform: {
-                Int($0)!
+                OneOrMore(.word)
             }
             Anchor.endOfLine
         }
@@ -97,15 +105,11 @@ extension Schedule {
         let everyInRangeRegex = Regex {
             Anchor.startOfLine
             Capture {
-                OneOrMore(.digit)
-            } transform: {
-                Int($0)!
+                OneOrMore(.word)
             }
             "-"
             Capture {
-                OneOrMore(.digit)
-            } transform: {
-                Int($0)!
+                OneOrMore(.word)
             }
             "/"
             Capture {
@@ -119,35 +123,99 @@ extension Schedule {
             Anchor.startOfLine
             Capture {
                 OneOrMore {
-                    OneOrMore(.digit)
+                    OneOrMore(.word)
                     ","
                 }
-                OneOrMore(.digit)
-            } transform: {
-                $0.split(separator: ",").map { Int($0)! }
+                OneOrMore(.word)
             }
             Anchor.endOfLine
         }
         if entry == "*" { return .any }
-        if let values = try? numberRegex.wholeMatch(in: entry) {
-            return try .init(transform(values.1))
-        } else if let values = try? rangeRegex.wholeMatch(in: entry) {
-            let array = try (values.1...values.2).map { try transform($0) }
-            return .init(array)
+        if let values = try? numberRegex.wholeMatch(in: entry), let value = transform(values.1) {
+            return .init(value)
+        } else if let values = try? rangeRegex.wholeMatch(in: entry), let lower = transform(values.1), let upper = transform(values.2) {
+            return .init(lower...upper)
         } else if let values = try? everyRegex.wholeMatch(in: entry) {
-            let numberOfValues = (range.count + values.1 - 1) / values.1
-            let array = try (0..<numberOfValues).map { try transform(range.lowerBound + $0 * values.1) }
+            let numberOfValues = (count + values.1 - 1) / values.1
+            let array = (0..<numberOfValues).map { range.lowerBound + $0 * values.1 }
             return .init(array)
-        } else if let values = try? everyInRangeRegex.wholeMatch(in: entry) {
-            let range = values.1...values.2
+        } else if let values = try? everyInRangeRegex.wholeMatch(in: entry), let lower = transform(values.1), let upper = transform(values.2) {
+            let range = lower...upper
             let numberOfValues = (range.count + values.3 - 1) / values.3
-            let array = try (0..<numberOfValues).map { try transform(range.lowerBound + $0 * values.3) }
+            let array = (0..<numberOfValues).map { range.lowerBound + $0 * values.3 }
             return .init(array)
         } else if let values = try? selectionRegex.wholeMatch(in: entry) {
-            let array = try values.1.map { try transform($0) }
-            return .init(array)
+            let values = try values.1.split(separator: ",").map {
+                guard let value = transform($0) else { throw ScheduleError("Unrecognised values \($0)") }
+                return value
+            }
+            return .init(values)
         } else {
             throw ScheduleError("Unrecognised crontab element \(entry)")
+        }
+    }
+
+    private static let dayNameNumberMap: [Substring: Int] = [
+        "sun": 0,
+        "mon": 1,
+        "tue": 2,
+        "wed": 3,
+        "thu": 4,
+        "fri": 5,
+        "sat": 6,
+    ]
+
+    private static let monthNameNumberMap: [Substring: Int] = [
+        "jan": 1,
+        "feb": 2,
+        "mar": 3,
+        "apr": 4,
+        "may": 5,
+        "jun": 6,
+        "jul": 7,
+        "aug": 8,
+        "sep": 9,
+        "oct": 10,
+        "nov": 11,
+        "dec": 12,
+    ]
+}
+
+protocol ExpressibleByRegexName {
+    init?<S: StringProtocol>(regexName: S)
+}
+
+extension Schedule.Day: ExpressibleByRegexName {
+    init?<S: StringProtocol>(regexName: S) {
+        switch regexName {
+        case "sun": self = .sunday
+        case "mon": self = .monday
+        case "tue": self = .tuesday
+        case "wed": self = .wednesday
+        case "thu": self = .thursday
+        case "fri": self = .friday
+        case "sat": self = .saturday
+        default: return nil
+        }
+    }
+}
+
+extension Schedule.Month: ExpressibleByRegexName {
+    init?<S: StringProtocol>(regexName: S) {
+        switch regexName {
+        case "jan": self = .january
+        case "feb": self = .february
+        case "mar": self = .march
+        case "apr": self = .april
+        case "may": self = .may
+        case "jun": self = .june
+        case "jul": self = .july
+        case "aug": self = .august
+        case "sep": self = .september
+        case "oct": self = .october
+        case "nov": self = .november
+        case "dec": self = .december
+        default: return nil
         }
     }
 }

--- a/Sources/Jobs/Scheduler/Schedule.swift
+++ b/Sources/Jobs/Scheduler/Schedule.swift
@@ -23,7 +23,7 @@ import Foundation
 /// Generates a Date at regular intervals (hourly, daily, weekly etc)
 public struct Schedule: Sendable, Equatable {
     /// Day of week
-    public enum Day: Int, Sendable, Comparable, Equatable {
+    public enum Day: Int, Sendable, Comparable, Equatable, Hashable {
         case sunday = 1
         case monday = 2
         case tuesday = 3
@@ -73,6 +73,17 @@ public struct Schedule: Sendable, Equatable {
 
         init(arrayLiteral values: Value...) {
             self.init(values)
+        }
+
+        var notAny: Bool {
+            switch self {
+            case .specific:
+                true
+            case .selection:
+                true
+            case .any:
+                false
+            }
         }
 
         var value: Value? {
@@ -157,6 +168,24 @@ public struct Schedule: Sendable, Equatable {
             var calendar = Calendar(identifier: .gregorian)
             calendar.timeZone = timeZone
             self.calendar = calendar
+        }
+        // if month is not any and both day and date are any then set day to selection with all the days
+        if self.month.notAny {
+            if case .any = self.day, case .any = self.date {
+                self.day = .selection([.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday])
+            }
+        }
+        // if either day or date are not any and hour is set to any then set it to selection with range of hours (0-23)
+        if self.date.notAny || self.day.notAny {
+            if case .any = hour {
+                self.hour = .selection(.init(0..<24))
+            }
+        }
+        // if hour is not any and minute is set to any then set minute to selection with all the minutes (0-59)
+        if self.hour.notAny {
+            if case .any = minute {
+                self.minute = .selection(.init(0..<60))
+            }
         }
     }
 

--- a/Sources/Jobs/Scheduler/Schedule.swift
+++ b/Sources/Jobs/Scheduler/Schedule.swift
@@ -23,7 +23,7 @@ import Foundation
 /// Generates a Date at regular intervals (hourly, daily, weekly etc)
 public struct Schedule: Sendable, Equatable {
     /// Day of week
-    public enum Day: Int, Sendable, Comparable, Equatable, Hashable {
+    public enum Day: Int, Sendable, Comparable, Equatable {
         case sunday = 1
         case monday = 2
         case tuesday = 3
@@ -67,7 +67,7 @@ public struct Schedule: Sendable, Equatable {
             self = .specific(value)
         }
 
-        init(_ values: [Value]) {
+        init<Seq: Sequence>(_ values: Seq) where Seq.Element == Value {
             self = .selection(.init(values.sorted()))
         }
 

--- a/Sources/Jobs/Scheduler/Schedule.swift
+++ b/Sources/Jobs/Scheduler/Schedule.swift
@@ -86,6 +86,26 @@ public struct Schedule: Sendable, Equatable {
             }
         }
 
+        func map<Return>(_ transform: (Value) throws -> Return) rethrows -> Parameter<Return> {
+            switch self {
+            case .specific(let value):
+                .specific(try transform(value))
+            case .selection(let values):
+                .selection(.init(try values.map { try transform($0) }))
+            case .any:
+                .any
+            }
+        }
+
+        func sorted() -> Parameter<Value> {
+            switch self {
+            case .selection(let values):
+                .selection(.init(values.sorted()))
+            default:
+                self
+            }
+        }
+
         var value: Value? {
             switch self {
             case .specific(let value):
@@ -391,6 +411,7 @@ public struct Schedule: Sendable, Equatable {
         self.updateScheduleForPrevDate(date: date)
     }
 
+    /// Days in each month
     private static let daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 }
 

--- a/Tests/JobsTests/JobSchedulerTests.swift
+++ b/Tests/JobsTests/JobSchedulerTests.swift
@@ -396,6 +396,24 @@ final class JobSchedulerTests: XCTestCase {
         )
     }
 
+    // test we are getting the right dates after restarting scheduler
+    func testScheduleLastDateWithOutOfRangeDates() async throws {
+        try testScheduleAfterReadingLastData(
+            schedule: .crontab("0 10 27-30 * *", timeZone: .init(secondsFromGMT: 0)!),
+            accuracy: .latest,
+            lastScheduled: "2023-02-03T05:00:00Z",
+            now: "2023-02-03T05:29:00Z",
+            expected: ["2023-02-27T10:00:00Z", "2023-02-28T10:00:00Z", "2023-03-27T10:00:00Z", "2023-03-28T10:00:00Z"]
+        )
+        try testScheduleAfterReadingLastData(
+            schedule: .crontab("0 10 27-30 * *", timeZone: .init(secondsFromGMT: 0)!),
+            accuracy: .latest,
+            lastScheduled: "2024-02-03T05:00:00Z",
+            now: "2024-02-03T05:29:00Z",
+            expected: ["2024-02-27T10:00:00Z", "2024-02-28T10:00:00Z", "2024-02-29T10:00:00Z", "2024-03-27T10:00:00Z"]
+        )
+    }
+
     // test we are getting the right dates from accuracy all
     func testScheduleLastDateAccuracyAll() async throws {
         struct TestParameters: JobParameters {

--- a/Tests/JobsTests/JobSchedulerTests.swift
+++ b/Tests/JobsTests/JobSchedulerTests.swift
@@ -357,6 +357,45 @@ final class JobSchedulerTests: XCTestCase {
         )
     }
 
+    // test we are getting the right dates after restarting scheduler
+    func testScheduleLastDateWithMultipleRanges() async throws {
+        try testScheduleAfterReadingLastData(
+            schedule: .crontab("0 3-5 4 * *", timeZone: .init(secondsFromGMT: 0)!),
+            accuracy: .latest,
+            lastScheduled: "2024-04-03T05:00:00Z",
+            now: "2024-04-04T02:29:00Z",
+            expected: ["2024-04-04T03:00:00Z", "2024-04-04T04:00:00Z", "2024-04-04T05:00:00Z", "2024-05-04T03:00:00Z"]
+        )
+        try testScheduleAfterReadingLastData(
+            schedule: .crontab("0 3-5 4 * *", timeZone: .init(secondsFromGMT: 0)!),
+            accuracy: .latest,
+            lastScheduled: "2024-04-04T02:17:00Z",
+            now: "2024-04-04T03:17:00Z",
+            expected: ["2024-04-04T03:17:00Z", "2024-04-04T04:00:00Z", "2024-04-04T05:00:00Z", "2024-05-04T03:00:00Z"]
+        )
+        try testScheduleAfterReadingLastData(
+            schedule: .crontab("0 3-5 4 * *", timeZone: .init(secondsFromGMT: 0)!),
+            accuracy: .latest,
+            lastScheduled: "2024-04-04T03:17:00Z",
+            now: "2024-04-04T03:17:00Z",
+            expected: ["2024-04-04T04:00:00Z", "2024-04-04T05:00:00Z", "2024-05-04T03:00:00Z"]
+        )
+        try testScheduleAfterReadingLastData(
+            schedule: .crontab("0 3-5 4 * *", timeZone: .init(secondsFromGMT: 0)!),
+            accuracy: .latest,
+            lastScheduled: "2024-04-04T03:17:00Z",
+            now: "2024-04-04T04:17:00Z",
+            expected: ["2024-04-04T04:17:00Z", "2024-04-04T05:00:00Z", "2024-05-04T03:00:00Z"]
+        )
+        try testScheduleAfterReadingLastData(
+            schedule: .crontab("0 3-5 3-4 * *", timeZone: .init(secondsFromGMT: 0)!),
+            accuracy: .latest,
+            lastScheduled: "2024-04-04T03:17:00Z",
+            now: "2024-04-04T04:17:00Z",
+            expected: ["2024-04-04T04:17:00Z", "2024-04-04T05:00:00Z", "2024-05-03T03:00:00Z"]
+        )
+    }
+
     // test we are getting the right dates from accuracy all
     func testScheduleLastDateAccuracyAll() async throws {
         struct TestParameters: JobParameters {

--- a/Tests/JobsTests/ScheduleTests.swift
+++ b/Tests/JobsTests/ScheduleTests.swift
@@ -75,8 +75,26 @@ final class ScheduleTests: XCTestCase {
             Schedule(minute: 15, hour: 10, date: .any, month: .any, day: [.sunday, .tuesday, .thursday, .saturday])
         )
         XCTAssertEqual(
+            try Schedule.crontab("15 10 */6 * *"),
+            Schedule(minute: 15, hour: 10, date: [1, 7, 13, 19, 25, 31], month: .any, day: .any)
+        )
+        XCTAssertEqual(
             try Schedule.crontab("15 10 1 */3 *"),
             Schedule(minute: 15, hour: 10, date: 1, month: [.january, .april, .july, .october], day: .any)
+        )
+    }
+    func testCrontabEveryInRange() throws {
+        XCTAssertEqual(
+            try Schedule.crontab("5 3-15/6 * * *"),
+            Schedule(minute: 5, hour: [3, 9, 15], date: .any, month: .any, day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("15 10 * * 1-6/2"),
+            Schedule(minute: 15, hour: 10, date: .any, month: .any, day: [.monday, .wednesday, .friday])
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("15 10 1 2-12/3 *"),
+            Schedule(minute: 15, hour: 10, date: 1, month: [.february, .may, .august, .november], day: .any)
         )
     }
     func testCrontabSelection() throws {

--- a/Tests/JobsTests/ScheduleTests.swift
+++ b/Tests/JobsTests/ScheduleTests.swift
@@ -179,6 +179,7 @@ final class ScheduleTests: XCTestCase {
                 day: .any
             )
         )
-        XCTAssertThrowsError(try Schedule.crontab("0 19 * 6 jan-sat"))
+        XCTAssertThrowsError(try Schedule.crontab("0 19 * jan-sat *"))
+        XCTAssertThrowsError(try Schedule.crontab("0 19 * may-feb"))
     }
 }

--- a/Tests/JobsTests/ScheduleTests.swift
+++ b/Tests/JobsTests/ScheduleTests.swift
@@ -192,11 +192,19 @@ final class ScheduleTests: XCTestCase {
             Schedule(minute: 0, hour: 0, date: .any, month: .any, day: .any)
         )
         XCTAssertEqual(
+            try Schedule.crontab("@weekly"),
+            Schedule(minute: 0, hour: 0, date: .any, month: .any, day: .init(.sunday))
+        )
+        XCTAssertEqual(
             try Schedule.crontab("@monthly"),
             Schedule(minute: 0, hour: 0, date: 1, month: .any, day: .any)
         )
         XCTAssertEqual(
             try Schedule.crontab("@yearly"),
+            Schedule(minute: 0, hour: 0, date: 1, month: .init(.january), day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("@annually"),
             Schedule(minute: 0, hour: 0, date: 1, month: .init(.january), day: .any)
         )
         XCTAssertThrowsError(try Schedule.crontab("@unrecognised"))

--- a/Tests/JobsTests/ScheduleTests.swift
+++ b/Tests/JobsTests/ScheduleTests.swift
@@ -182,4 +182,23 @@ final class ScheduleTests: XCTestCase {
         XCTAssertThrowsError(try Schedule.crontab("0 19 * jan-sat *"))
         XCTAssertThrowsError(try Schedule.crontab("0 19 * may-feb"))
     }
+    func testNicknames() throws {
+        XCTAssertEqual(
+            try Schedule.crontab("@hourly"),
+            Schedule(minute: 0, hour: .any, date: .any, month: .any, day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("@daily"),
+            Schedule(minute: 0, hour: 0, date: .any, month: .any, day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("@monthly"),
+            Schedule(minute: 0, hour: 0, date: 1, month: .any, day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("@yearly"),
+            Schedule(minute: 0, hour: 0, date: 1, month: .init(.january), day: .any)
+        )
+        XCTAssertThrowsError(try Schedule.crontab("@unrecognised"))
+    }
 }

--- a/Tests/JobsTests/ScheduleTests.swift
+++ b/Tests/JobsTests/ScheduleTests.swift
@@ -58,7 +58,7 @@ final class ScheduleTests: XCTestCase {
         )
         XCTAssertEqual(
             try Schedule.crontab("5 12 * * 6-7"),
-            Schedule(minute: 5, hour: 12, date: .any, month: .any, day: [.sunday, .saturday])
+            Schedule(minute: 5, hour: 12, date: .any, month: .any, day: [.saturday, .sunday])
         )
     }
     func testCrontabEvery() throws {
@@ -126,5 +126,59 @@ final class ScheduleTests: XCTestCase {
                 day: .init([.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday])
             )
         )
+    }
+    func testDayNames() throws {
+        XCTAssertEqual(
+            try Schedule.crontab("0 8 * * mon"),
+            Schedule(minute: 0, hour: 8, date: .any, month: .any, day: .init(.monday))
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("0 19 * 6 tue-sat"),
+            Schedule(
+                minute: 0,
+                hour: 19,
+                date: .any,
+                month: .init(.june),
+                day: .init([.tuesday, .wednesday, .thursday, .friday, .saturday])
+            )
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("0 19 * 6 sun,wed,fri"),
+            Schedule(
+                minute: 0,
+                hour: 19,
+                date: .any,
+                month: .init(.june),
+                day: .init([.sunday, .wednesday, .friday])
+            )
+        )
+        XCTAssertThrowsError(try Schedule.crontab("0 19 * 6 sun,jan,fri"))
+    }
+    func testMonthNames() throws {
+        XCTAssertEqual(
+            try Schedule.crontab("0 8 * jan *"),
+            Schedule(minute: 0, hour: 8, date: .any, month: .init(.january), day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("0 19 * feb-may *"),
+            Schedule(
+                minute: 0,
+                hour: 19,
+                date: .any,
+                month: [.february, .march, .april, .may],
+                day: .any
+            )
+        )
+        XCTAssertEqual(
+            try Schedule.crontab("0 19 * jun,jul,aug *"),
+            Schedule(
+                minute: 0,
+                hour: 19,
+                date: .any,
+                month: [.june, .july, .august],
+                day: .any
+            )
+        )
+        XCTAssertThrowsError(try Schedule.crontab("0 19 * 6 jan-sat"))
     }
 }

--- a/Tests/JobsTests/ScheduleTests.swift
+++ b/Tests/JobsTests/ScheduleTests.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2025 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+@testable import Jobs
+
+final class ScheduleTests: XCTestCase {
+    func testCrontabNumbers() throws {
+        XCTAssertEqual(
+            try Schedule(crontab: "5 12 20 4 *"),
+            Schedule(minute: 5, hour: 12, date: 20, month: .init(.april), day: .any)
+        )
+    }
+    func testCrontabDays() throws {
+        XCTAssertEqual(
+            try Schedule(crontab: "0 12 * * 0"),
+            Schedule(minute: 0, hour: 12, date: .any, month: .any, day: .init(.sunday))
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "0 12 * * 7"),
+            Schedule(minute: 0, hour: 12, date: .any, month: .any, day: .init(.sunday))
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "0 12 * * 4"),
+            Schedule(minute: 0, hour: 12, date: .any, month: .any, day: .init(.thursday))
+        )
+    }
+    func testCrontabRanges() throws {
+        XCTAssertEqual(
+            try Schedule(crontab: "5 12-14 20 4 *"),
+            Schedule(minute: 5, hour: [12, 13, 14], date: 20, month: .init(.april), day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "5 12 20 6-9 *"),
+            Schedule(
+                minute: 5,
+                hour: 12,
+                date: 20,
+                month: [.june, .july, .august, .september],
+                day: .any
+            )
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "5 12 * * 0-2"),
+            Schedule(minute: 5, hour: 12, date: .any, month: .any, day: [.sunday, .monday, .tuesday])
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "5 12 * * 6-7"),
+            Schedule(minute: 5, hour: 12, date: .any, month: .any, day: [.sunday, .saturday])
+        )
+    }
+    func testCrontabEvery() throws {
+        XCTAssertEqual(
+            try Schedule(crontab: "5 */6 * * *"),
+            Schedule(minute: 5, hour: [0, 6, 12, 18], date: .any, month: .any, day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "5 */5 * * *"),
+            Schedule(minute: 5, hour: [0, 5, 10, 15, 20], date: .any, month: .any, day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "15 10 * * */2"),
+            Schedule(minute: 15, hour: 10, date: .any, month: .any, day: [.sunday, .tuesday, .thursday, .saturday])
+        )
+    }
+    func testCrontabSelection() throws {
+        XCTAssertEqual(
+            try Schedule(crontab: "5 8,16 * * *"),
+            Schedule(minute: 5, hour: [8, 16], date: .any, month: .any, day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "5,10 6 * * *"),
+            Schedule(minute: [5, 10], hour: 6, date: .any, month: .any, day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "15 10 2 1,6,9 *"),
+            Schedule(minute: 15, hour: 10, date: 2, month: [.january, .june, .september], day: .any)
+        )
+    }
+}

--- a/Tests/JobsTests/ScheduleTests.swift
+++ b/Tests/JobsTests/ScheduleTests.swift
@@ -19,31 +19,31 @@ import XCTest
 final class ScheduleTests: XCTestCase {
     func testCrontabNumbers() throws {
         XCTAssertEqual(
-            try Schedule(crontab: "5 12 20 4 *"),
+            try Schedule.crontab("5 12 20 4 *"),
             Schedule(minute: 5, hour: 12, date: 20, month: .init(.april), day: .any)
         )
     }
     func testCrontabDays() throws {
         XCTAssertEqual(
-            try Schedule(crontab: "0 12 * * 0"),
+            try Schedule.crontab("0 12 * * 0"),
             Schedule(minute: 0, hour: 12, date: .any, month: .any, day: .init(.sunday))
         )
         XCTAssertEqual(
-            try Schedule(crontab: "0 12 * * 7"),
+            try Schedule.crontab("0 12 * * 7"),
             Schedule(minute: 0, hour: 12, date: .any, month: .any, day: .init(.sunday))
         )
         XCTAssertEqual(
-            try Schedule(crontab: "0 12 * * 4"),
+            try Schedule.crontab("0 12 * * 4"),
             Schedule(minute: 0, hour: 12, date: .any, month: .any, day: .init(.thursday))
         )
     }
     func testCrontabRanges() throws {
         XCTAssertEqual(
-            try Schedule(crontab: "5 12-14 20 4 *"),
+            try Schedule.crontab("5 12-14 20 4 *"),
             Schedule(minute: 5, hour: [12, 13, 14], date: 20, month: .init(.april), day: .any)
         )
         XCTAssertEqual(
-            try Schedule(crontab: "5 12 20 6-9 *"),
+            try Schedule.crontab("5 12 20 6-9 *"),
             Schedule(
                 minute: 5,
                 hour: 12,
@@ -53,49 +53,49 @@ final class ScheduleTests: XCTestCase {
             )
         )
         XCTAssertEqual(
-            try Schedule(crontab: "5 12 * * 0-2"),
+            try Schedule.crontab("5 12 * * 0-2"),
             Schedule(minute: 5, hour: 12, date: .any, month: .any, day: [.sunday, .monday, .tuesday])
         )
         XCTAssertEqual(
-            try Schedule(crontab: "5 12 * * 6-7"),
+            try Schedule.crontab("5 12 * * 6-7"),
             Schedule(minute: 5, hour: 12, date: .any, month: .any, day: [.sunday, .saturday])
         )
     }
     func testCrontabEvery() throws {
         XCTAssertEqual(
-            try Schedule(crontab: "5 */6 * * *"),
+            try Schedule.crontab("5 */6 * * *"),
             Schedule(minute: 5, hour: [0, 6, 12, 18], date: .any, month: .any, day: .any)
         )
         XCTAssertEqual(
-            try Schedule(crontab: "5 */5 * * *"),
+            try Schedule.crontab("5 */5 * * *"),
             Schedule(minute: 5, hour: [0, 5, 10, 15, 20], date: .any, month: .any, day: .any)
         )
         XCTAssertEqual(
-            try Schedule(crontab: "15 10 * * */2"),
+            try Schedule.crontab("15 10 * * */2"),
             Schedule(minute: 15, hour: 10, date: .any, month: .any, day: [.sunday, .tuesday, .thursday, .saturday])
         )
     }
     func testCrontabSelection() throws {
         XCTAssertEqual(
-            try Schedule(crontab: "5 8,16 * * *"),
+            try Schedule.crontab("5 8,16 * * *"),
             Schedule(minute: 5, hour: [8, 16], date: .any, month: .any, day: .any)
         )
         XCTAssertEqual(
-            try Schedule(crontab: "5,10 6 * * *"),
+            try Schedule.crontab("5,10 6 * * *"),
             Schedule(minute: [5, 10], hour: 6, date: .any, month: .any, day: .any)
         )
         XCTAssertEqual(
-            try Schedule(crontab: "15 10 2 1,6,9 *"),
+            try Schedule.crontab("15 10 2 1,6,9 *"),
             Schedule(minute: 15, hour: 10, date: 2, month: [.january, .june, .september], day: .any)
         )
     }
     func testFixedSelections() throws {
         XCTAssertEqual(
-            try Schedule(crontab: "* 8 * * *"),
+            try Schedule.crontab("* 8 * * *"),
             Schedule(minute: .init(Array(0..<60)), hour: 8, date: .any, month: .any, day: .any)
         )
         XCTAssertEqual(
-            try Schedule(crontab: "* * * 6 *"),
+            try Schedule.crontab("* * * 6 *"),
             Schedule(
                 minute: .init(0..<60),
                 hour: .init(0..<24),

--- a/Tests/JobsTests/ScheduleTests.swift
+++ b/Tests/JobsTests/ScheduleTests.swift
@@ -74,6 +74,10 @@ final class ScheduleTests: XCTestCase {
             try Schedule.crontab("15 10 * * */2"),
             Schedule(minute: 15, hour: 10, date: .any, month: .any, day: [.sunday, .tuesday, .thursday, .saturday])
         )
+        XCTAssertEqual(
+            try Schedule.crontab("15 10 1 */3 *"),
+            Schedule(minute: 15, hour: 10, date: 1, month: [.january, .april, .july, .october], day: .any)
+        )
     }
     func testCrontabSelection() throws {
         XCTAssertEqual(

--- a/Tests/JobsTests/ScheduleTests.swift
+++ b/Tests/JobsTests/ScheduleTests.swift
@@ -89,4 +89,20 @@ final class ScheduleTests: XCTestCase {
             Schedule(minute: 15, hour: 10, date: 2, month: [.january, .june, .september], day: .any)
         )
     }
+    func testFixedSelections() throws {
+        XCTAssertEqual(
+            try Schedule(crontab: "* 8 * * *"),
+            Schedule(minute: .init(Array(0..<60)), hour: 8, date: .any, month: .any, day: .any)
+        )
+        XCTAssertEqual(
+            try Schedule(crontab: "* * * 6 *"),
+            Schedule(
+                minute: .init(0..<60),
+                hour: .init(0..<24),
+                date: .any,
+                month: .init(.june),
+                day: .init([.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday])
+            )
+        )
+    }
 }


### PR DESCRIPTION
Add support for crontab style schedules
```swift
let jobSchedule = JobSchedule([
    (job: RemoveDeadSessionsJob(), schedule: .crontab("0 4 * * 7")), // four in the morning on Sunday
    (job: BirthdayRemindersJob(), schedule: .crontab("0 9,16 * * 1-5")), // nine in the morning and four in the afternoon on week days
])
```
Syntax supported
  `*` - wildcard
  `*/n` - repeating value every so many units
  `a-b` range of values
  `a-b/n` - repeating value every so many units within range
  `a,b,c...` selection of values

If both date and week day are both set we can't support one of them being a range of values.
Currently don't support dealing with dates that go past the end of the month eg 30th Feb.  This should be fixable