### PR TITLE
Add JobRetryStrategy

### DIFF
--- a/Sources/Jobs/JobQueueOptions.swift
+++ b/Sources/Jobs/JobQueueOptions.swift
@@ -16,31 +16,10 @@ import struct Foundation.TimeInterval
 
 /// JobQueueOptions
 public struct JobQueueOptions: Sendable {
-    /// Maximum Backoff - default is 120.0 seconds
-    public var maximumBackoff: TimeInterval
-    /// Maximum jitter - default is 15 seconds
-    public var maxJitter: TimeInterval
-    /// Minimum jitter - default is 5 seconds
-    public var minJitter: TimeInterval
-    /// Computes a random jitter between minJitter and maxJitter
-    internal var jitter: Double {
-        Double.random(in: self.minJitter..<self.maxJitter)
-    }
+    let retryStrategy: JobRetryStrategy
 
     /// Initialize a JobQueueOptions
-    /// The current backoff computation uses jitters
-    /// see Wikipedia if  not familiar  with the topic https://en.wikipedia.org/wiki/Exponential_backoff
-    /// - Parameters:
-    ///   - maximumBackoff: maximum backoff allowed, default 120 seconds
-    ///   - maxJitter: maximum jitter
-    ///   - minJitter: minimum jitter
-    public init(
-        maximumBackoff: TimeInterval = 120.0,
-        maxJitter: TimeInterval = 15.0,
-        minJitter: TimeInterval = 5.0
-    ) {
-        self.maximumBackoff = maximumBackoff
-        self.maxJitter = maxJitter
-        self.minJitter = minJitter
+    public init(defaultRetryStrategy: any JobRetryStrategy = .exponentialJitter()) {
+        self.retryStrategy = defaultRetryStrategy
     }
 }

--- a/Sources/Jobs/JobRetry.swift
+++ b/Sources/Jobs/JobRetry.swift
@@ -14,12 +14,6 @@
 
 import Foundation
 
-/// Define whether a job should be retried or not and how long before retrying
-public enum JobRetryResult {
-    case retryAfter(TimeInterval)
-    case dontRetry
-}
-
 /// Strategy deciding whether we should retry a failed job
 public protocol JobRetryStrategy: Sendable {
     ///  Calculate whether we should retry a failed job and how long we wait before retrying

--- a/Sources/Jobs/JobRetry.swift
+++ b/Sources/Jobs/JobRetry.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2025 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Define whether a job should be retried or not and how long before retrying
+public enum JobRetryResult {
+    case retryAfter(TimeInterval)
+    case dontRetry
+}
+
+/// Strategy deciding whether we should retry a failed job
+public protocol JobRetryStrategy: Sendable {
+    ///  Calculate whether we should retry a failed job and how long we wait before retrying
+    /// - Parameters:
+    ///   - attempt: Attempt number of job
+    ///   - error: Error that was thrown by failed job
+    /// - Returns: Whether we should retry a failed job
+    func shouldRetry(attempt: Int, error: Error) -> Bool
+
+    ///  Calculate backoff amount
+    /// - Parameter attempt: Attempt number
+    /// - Returns: Retry backoff
+    func calculateBackoff(attempt: Int) -> TimeInterval
+}
+
+/// Never retry failed jobs
+public struct NoRetryJobRetryStrategy: JobRetryStrategy {
+    public func shouldRetry(attempt: Int, error: Error) -> Bool { false }
+    public func calculateBackoff(attempt: Int) -> TimeInterval { 0 }
+
+}
+
+extension JobRetryStrategy where Self == NoRetryJobRetryStrategy {
+    /// Dont retry job strategy
+    public static var dontRetry: Self { .init() }
+}
+
+/// Retry failed jobs with an exponentially increasing delay
+///
+/// See https://en.wikipedia.org/wiki/Exponential_backoff
+public struct ExponentialJitterJobRetryStrategy: JobRetryStrategy {
+    /// Maximum attempts - default is 4
+    public var maxAttempts: Int
+    /// Maximum Delay - default is 120.0 seconds
+    public var maxBackoff: Double
+    /// Minimum jitter - default is 0 seconds
+    public var minJitter: TimeInterval
+    /// Maximum jitter - default is 10 seconds
+    public var maxJitter: TimeInterval
+
+    public init(maxAttempts: Int = 4, maxBackoff: TimeInterval = 120, minJitter: TimeInterval = 0, maxJitter: TimeInterval = 10) {
+        self.maxAttempts = maxAttempts
+        self.maxBackoff = maxBackoff
+        self.maxJitter = maxJitter
+        self.minJitter = minJitter
+    }
+
+    public func shouldRetry(attempt: Int, error: any Error) -> Bool {
+        attempt < maxAttempts
+    }
+
+    public func calculateBackoff(attempt: Int) -> TimeInterval {
+        let exp = exp2(Double(attempt))
+        let delay = min(exp, self.maxBackoff)
+        return TimeInterval(Double.random(in: self.minJitter..<self.maxJitter) + delay)
+    }
+}
+
+extension JobRetryStrategy where Self == ExponentialJitterJobRetryStrategy {
+    ///  Retry job with exponential backoff
+    /// - Parameters:
+    ///   - maxAttempts: Maximum retry attempts
+    ///   - maxBackoff: Maximum backoff returned
+    ///   - minJitter: Minimum jitter
+    ///   - maxJitter: Maximum jitter
+    public static func exponentialJitter(
+        maxAttempts: Int = 4,
+        maxBackoff: TimeInterval = 120,
+        minJitter: TimeInterval = 0,
+        maxJitter: TimeInterval = 10
+    ) -> Self { .init(maxAttempts: maxAttempts, maxBackoff: maxBackoff, minJitter: minJitter, maxJitter: maxJitter) }
+}

--- a/Sources/Jobs/Middleware/JobMiddleware.swift
+++ b/Sources/Jobs/Middleware/JobMiddleware.swift
@@ -33,7 +33,11 @@ public protocol JobMiddleware: Sendable {
     ///   - context: Job context
     ///   - next: Next handler
     /// - Throws:
-    func handleJob(job: any JobInstanceProtocol, context: JobContext, next: (any JobInstanceProtocol, JobContext) async throws -> Void) async throws
+    func handleJob(
+        job: any JobInstanceProtocol,
+        context: JobContext,
+        next: (any JobInstanceProtocol, JobContext) async throws -> Void
+    ) async throws
 }
 
 @_documentation(visibility: internal)

--- a/Sources/Jobs/Middleware/MetricsMiddleware.swift
+++ b/Sources/Jobs/Middleware/MetricsMiddleware.swift
@@ -136,7 +136,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
             )
             throw error
         } catch {
-            if job.didFail {
+            if !job.shouldRetry(error: error) {
                 self.updateMetrics(
                     for: job.name,
                     startTime: startTime,

--- a/Sources/Jobs/Middleware/TracingMiddleware.swift
+++ b/Sources/Jobs/Middleware/TracingMiddleware.swift
@@ -43,7 +43,7 @@ public struct TracingJobMiddleware: JobMiddleware {
                 try await next(job, context)
             } catch {
                 span.recordError(error)
-                if job.didFail || error is CancellationError {
+                if !job.shouldRetry(error: error) || error is CancellationError {
                     span.attributes["job.failed"] = true
                 }
                 throw error

--- a/Tests/JobsTests/JobMiddlewareTests.swift
+++ b/Tests/JobsTests/JobMiddlewareTests.swift
@@ -58,7 +58,7 @@ final class JobMiddlewareTests: XCTestCase {
         }
         struct FakeJobInstance: JobInstanceProtocol {
             let parameters = TestParameters(value: "test")
-            let maxRetryCount = 1
+            let retryStrategy: JobRetryStrategy = .exponentialJitter(maxAttempts: 1)
             let queuedAt = Date.now
             let attempts: Int? = 0
             let traceContext: [String: String]? = nil
@@ -93,7 +93,7 @@ final class JobMiddlewareTests: XCTestCase {
             }
             struct FakeJobInstance: JobInstanceProtocol {
                 let parameters = TestParameters(value: "test")
-                let maxRetryCount = 1
+                let retryStrategy: JobRetryStrategy = .exponentialJitter(maxAttempts: 1)
                 let queuedAt = Date.now
                 let attempts: Int? = 0
                 let traceContext: [String: String]? = nil
@@ -127,7 +127,7 @@ final class JobMiddlewareTests: XCTestCase {
             }
             struct FakeJobInstance: JobInstanceProtocol {
                 let parameters = TestParameters(value: "test")
-                let maxRetryCount = 1
+                let retryStrategy: JobRetryStrategy = .exponentialJitter(maxAttempts: 1)
                 let queuedAt = Date.now
                 let attempts: Int? = 0
                 let traceContext: [String: String]? = nil

--- a/Tests/JobsTests/TracingTests.swift
+++ b/Tests/JobsTests/TracingTests.swift
@@ -75,10 +75,13 @@ final class TracingTests: XCTestCase {
         let failJob = NIOLockedValueBox(true)
         var logger = Logger(label: "JobsTests")
         logger.logLevel = .debug
-        let jobQueue = JobQueue(.memory, numWorkers: 1, logger: logger, options: .init(maxJitter: 0.25, minJitter: 0.01)) {
+        let jobQueue = JobQueue(.memory, numWorkers: 1, logger: logger) {
             TracingJobMiddleware()
         }
-        jobQueue.registerJob(parameters: TestParameters.self, maxRetryCount: 4) { parameters, context in
+        jobQueue.registerJob(
+            parameters: TestParameters.self,
+            retryStrategy: .exponentialJitter(maxAttempts: 4, maxBackoff: 0.5, minJitter: 0.0, maxJitter: 0.25)
+        ) { parameters, context in
             if failJob.withLockedValue({
                 let value = $0
                 $0 = false


### PR DESCRIPTION
Add custom retry strategy for jobs.
```swift
jobQueue.registerJob(
    parameters: TestParameters.self,
    retryStrategy: .exponentialJitter(maxAttempts: 3, maxBackoff: 60, minJitter: 0.0, maxJitter: 5.0)
) { _, _ in
    doStuff()
}

Currently only retry strategies implemented are `dontRetry` and `exponentialJitter`