### PR TITLE
Public Retry interface uses Duration instead of Double

### DIFF
--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -123,7 +123,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
 
                 let attempts = (job.attempts ?? 0) + 1
                 let delay = job.retryStrategy.calculateBackoff(attempt: attempts)
-                let delayUntil = Date.now.addingTimeInterval(delay)
+                let delayUntil = Date.now._advanced(by: delay)
 
                 /// retry the current job
                 try await self.queue.retry(
@@ -160,4 +160,14 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
 
 extension JobQueueHandler: CustomStringConvertible {
     public var description: String { "JobQueueHandler<\(String(describing: Queue.self))>" }
+}
+
+extension Date {
+    // private version of advancing Date by Duration
+    internal func _advanced(by duration: Duration) -> Date {
+        var timeValue = self.timeIntervalSinceReferenceDate
+        timeValue += Double(duration.components.seconds)
+        timeValue += Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
+        return Date(timeIntervalSinceReferenceDate: timeValue)
+    }
 }

--- a/Tests/JobsTests/MetricsTests.swift
+++ b/Tests/JobsTests/MetricsTests.swift
@@ -346,7 +346,7 @@ final class MetricsTests: XCTestCase {
         ) { MetricsJobMiddleware() }
         jobQueue.registerJob(
             parameters: TestParameter.self,
-            retryStrategy: .exponentialJitter(maxAttempts: 3, maxBackoff: 0.5, minJitter: 0.0, maxJitter: 0.25)
+            retryStrategy: .exponentialJitter(maxAttempts: 3, maxBackoff: .seconds(0.5), minJitter: -0.25, maxJitter: 0.25)
         ) { _, _ in
 
             defer {
@@ -394,7 +394,7 @@ final class MetricsTests: XCTestCase {
         ) { MetricsJobMiddleware() }
         jobQueue.registerJob(
             parameters: TestParameter.self,
-            retryStrategy: .exponentialJitter(maxAttempts: 3, maxBackoff: 0.5, minJitter: 0.0, maxJitter: 0.01)
+            retryStrategy: .exponentialJitter(maxAttempts: 3, maxBackoff: .seconds(0.5), minJitter: 0.0, maxJitter: 0.01)
         ) { _, _ in
             expectation.fulfill()
             throw FailedError()

--- a/Tests/JobsTests/TracingTests.swift
+++ b/Tests/JobsTests/TracingTests.swift
@@ -85,7 +85,7 @@ final class TracingTests: XCTestCase {
         }
         jobQueue.registerJob(
             parameters: TestParameters.self,
-            retryStrategy: .exponentialJitter(maxAttempts: 4, maxBackoff: 0.5, minJitter: 0.0, maxJitter: 0.25)
+            retryStrategy: .exponentialJitter(maxAttempts: 4, maxBackoff: .seconds(0.5), minJitter: 0.0, maxJitter: 0.25)
         ) { parameters, context in
             if failJob.withLockedValue({
                 let value = $0


### PR DESCRIPTION
This PR changes the public API for RetryStrategy to use Duration instead of a Double.
It also changes the meaning of the jitter values to be fractions of the calculated backoff. 