### PR TITLE
Add job queue name to metrics/spans

### DIFF
--- a/Sources/Jobs/JobContext.swift
+++ b/Sources/Jobs/JobContext.swift
@@ -23,7 +23,7 @@ import Foundation
 /// Context of running job
 public struct JobExecutionContext {
     /// Job instance identifier
-    public let jobInstanceID: String
+    public let jobID: String
     /// Logger
     public let logger: Logger
     /// Time when the job was scheduled
@@ -36,5 +36,5 @@ public struct JobExecutionContext {
 /// context for job being adding/removed from queue
 public struct JobQueueContext {
     /// Job instance identifier
-    public let jobInstanceID: String
+    public let jobID: String
 }

--- a/Sources/Jobs/JobContext.swift
+++ b/Sources/Jobs/JobContext.swift
@@ -21,7 +21,7 @@ import Foundation
 #endif
 
 /// Context of running job
-public struct JobContext {
+public struct JobExecutionContext {
     /// Job instance identifier
     public let jobInstanceID: String
     /// Logger
@@ -31,4 +31,10 @@ public struct JobContext {
     public let queuedAt: Date
     /// Next time job is scheduled to run
     public let nextScheduledAt: Date?
+}
+
+/// context for job being adding/removed from queue
+public struct JobQueueContext {
+    /// Job instance identifier
+    public let jobInstanceID: String
 }

--- a/Sources/Jobs/JobDefinition.swift
+++ b/Sources/Jobs/JobDefinition.swift
@@ -15,7 +15,7 @@
 /// Job definition type
 public struct JobDefinition<Parameters: JobParameters>: Sendable {
     let retryStrategy: any JobRetryStrategy
-    let _execute: @Sendable (Parameters, JobContext) async throws -> Void
+    let _execute: @Sendable (Parameters, JobExecutionContext) async throws -> Void
 
     ///  Initialize JobDefinition
     /// - Parameters:
@@ -25,7 +25,7 @@ public struct JobDefinition<Parameters: JobParameters>: Sendable {
     public init(
         parameters: Parameters.Type = Parameters.self,
         retryStrategy: any JobRetryStrategy = .dontRetry,
-        execute: @escaping @Sendable (Parameters, JobContext) async throws -> Void
+        execute: @escaping @Sendable (Parameters, JobExecutionContext) async throws -> Void
     ) where Parameters: JobParameters {
         self.retryStrategy = retryStrategy
         self._execute = execute
@@ -39,13 +39,13 @@ public struct JobDefinition<Parameters: JobParameters>: Sendable {
     public init(
         parameters: Parameters.Type = Parameters.self,
         maxRetryCount: Int,
-        execute: @escaping @Sendable (Parameters, JobContext) async throws -> Void
+        execute: @escaping @Sendable (Parameters, JobExecutionContext) async throws -> Void
     ) where Parameters: JobParameters {
         self.retryStrategy = ExponentialJitterJobRetryStrategy(maxAttempts: maxRetryCount)
         self._execute = execute
     }
 
-    func execute(_ parameters: Parameters, context: JobContext) async throws {
+    func execute(_ parameters: Parameters, context: JobExecutionContext) async throws {
         try await self._execute(parameters, context)
     }
 }

--- a/Sources/Jobs/JobInstance.swift
+++ b/Sources/Jobs/JobInstance.swift
@@ -37,7 +37,7 @@ public protocol JobInstanceProtocol: Sendable {
     /// Next time job is scheduled to run
     var nextScheduledAt: Date? { get }
     /// Function to execute the job
-    func execute(context: JobContext) async throws
+    func execute(context: JobExecutionContext) async throws
 }
 
 extension JobInstanceProtocol {
@@ -84,7 +84,7 @@ struct JobInstance<Parameters: JobParameters>: JobInstanceProtocol {
     /// Next time job is scheduled to run
     var nextScheduledAt: Date? { self.data.nextScheduledAt }
 
-    func execute(context: JobContext) async throws {
+    func execute(context: JobExecutionContext) async throws {
         try await self.job.execute(self.data.parameters, context: context)
     }
 

--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -124,7 +124,7 @@ public struct JobQueue<Queue: JobQueueDriver>: JobQueueProtocol {
         let instanceID = try await self.queue.push(request, options: options)
         await self.handler.middleware.onPushJob(
             parameters: parameters,
-            context: .init(jobInstanceID: instanceID.description)
+            context: .init(jobID: instanceID.description)
         )
         self.logger.debug(
             "Pushed Job",
@@ -155,7 +155,7 @@ public struct JobQueue<Queue: JobQueueDriver>: JobQueueProtocol {
         let instanceID = try await self.queue.push(request, options: options)
         await self.handler.middleware.onPushJob(
             parameters: parameters,
-            context: .init(jobInstanceID: instanceID.description)
+            context: .init(jobID: instanceID.description)
         )
         self.logger.debug(
             "Pushed Job",

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -68,7 +68,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
         case .success(let job):
             await self.middleware.onPopJob(
                 result: .success(job),
-                context: .init(jobInstanceID: jobResult.id.description)
+                context: .init(jobID: jobResult.id.description)
             )
             logger[metadataKey: "JobName"] = .string(job.name)
             try await self.runJob(id: jobResult.id, job: job, logger: logger)
@@ -91,7 +91,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
             try await self.queue.failed(jobID: jobResult.id, error: error)
             await self.middleware.onPopJob(
                 result: .failure(error),
-                context: .init(jobInstanceID: jobResult.id.description)
+                context: .init(jobID: jobResult.id.description)
             )
         }
     }
@@ -102,7 +102,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
         do {
             do {
                 let context = JobExecutionContext(
-                    jobInstanceID: jobID.description,
+                    jobID: jobID.description,
                     logger: logger,
                     queuedAt: job.queuedAt,
                     nextScheduledAt: job.nextScheduledAt

--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -66,7 +66,10 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
 
         switch jobResult.result {
         case .success(let job):
-            await self.middleware.onPopJob(result: .success(job), jobInstanceID: jobResult.id.description)
+            await self.middleware.onPopJob(
+                result: .success(job),
+                context: .init(jobInstanceID: jobResult.id.description)
+            )
             logger[metadataKey: "JobName"] = .string(job.name)
             try await self.runJob(id: jobResult.id, job: job, logger: logger)
 
@@ -86,7 +89,10 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                 logger.debug("Job failed to decode")
             }
             try await self.queue.failed(jobID: jobResult.id, error: error)
-            await self.middleware.onPopJob(result: .failure(error), jobInstanceID: jobResult.id.description)
+            await self.middleware.onPopJob(
+                result: .failure(error),
+                context: .init(jobInstanceID: jobResult.id.description)
+            )
         }
     }
 
@@ -95,7 +101,7 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
         logger.debug("Starting Job")
         do {
             do {
-                let context = JobContext(
+                let context = JobExecutionContext(
                     jobInstanceID: jobID.description,
                     logger: logger,
                     queuedAt: job.queuedAt,

--- a/Sources/Jobs/Middleware/JobMiddleware.swift
+++ b/Sources/Jobs/Middleware/JobMiddleware.swift
@@ -19,13 +19,13 @@ public protocol JobMiddleware: Sendable {
     /// - Parameters:
     ///   - parameters: Job parameters
     ///   - jobInstanceID: Job instance identifier
-    func onPushJob<Parameters: JobParameters>(parameters: Parameters, jobInstanceID: String) async
+    func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async
     /// Job has been popped off the queue and decoded (with decode errors reported)
     ///
     /// - Parameters:
     ///   - result: Result of popping the job from the queue (Either job instance or error)
     ///   - jobInstanceID: Job instance identifer
-    func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, jobInstanceID: String) async
+    func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async
     /// Handle job and pass it onto next handler
     ///
     /// - Parameters:
@@ -35,8 +35,8 @@ public protocol JobMiddleware: Sendable {
     /// - Throws:
     func handleJob(
         job: any JobInstanceProtocol,
-        context: JobContext,
-        next: (any JobInstanceProtocol, JobContext) async throws -> Void
+        context: JobExecutionContext,
+        next: (any JobInstanceProtocol, JobExecutionContext) async throws -> Void
     ) async throws
 }
 
@@ -46,16 +46,16 @@ public struct NullJobMiddleware: JobMiddleware {
 
     /// Job has been pushed onto the queue
     @inlinable
-    public func onPushJob<Parameters: JobParameters>(parameters: Parameters, jobInstanceID: String) async {}
+    public func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {}
     /// Job has been popped off the queue and decoded (with decode errors reported)
     @inlinable
-    public func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, jobInstanceID: String) async {}
+    public func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {}
     /// Handle job and pass it onto next handler (works like middleware in Hummingbird)
     @inlinable
     public func handleJob(
         job: any JobInstanceProtocol,
-        context: JobContext,
-        next: (any JobInstanceProtocol, JobContext) async throws -> Void
+        context: JobExecutionContext,
+        next: (any JobInstanceProtocol, JobExecutionContext) async throws -> Void
     ) async throws {
         try await next(job, context)
     }
@@ -66,24 +66,24 @@ struct OptionalJobMiddleware<Middleware: JobMiddleware>: JobMiddleware {
     let middleware: Middleware?
 
     @inlinable
-    func onPushJob<Parameters: JobParameters>(parameters: Parameters, jobInstanceID: String) async {
+    func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
         if let middleware {
-            await middleware.onPushJob(parameters: parameters, jobInstanceID: jobInstanceID)
+            await middleware.onPushJob(parameters: parameters, context: context)
         }
     }
     /// Job has been popped off the queue and decoded (with decode errors reported)
     @inlinable
-    func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, jobInstanceID: String) async {
+    func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {
         if let middleware {
-            await middleware.onPopJob(result: result, jobInstanceID: jobInstanceID)
+            await middleware.onPopJob(result: result, context: context)
         }
     }
     /// Process job and pass it onto next handler (works like middleware in Hummingbird)
     @inlinable
     func handleJob(
         job: any JobInstanceProtocol,
-        context: JobContext,
-        next: (any JobInstanceProtocol, JobContext) async throws -> Void
+        context: JobExecutionContext,
+        next: (any JobInstanceProtocol, JobExecutionContext) async throws -> Void
     ) async throws {
         guard let middleware else {
             return try await next(job, context)
@@ -99,22 +99,22 @@ struct TwoJobMiddlewares<Middleware1: JobMiddleware, Middleware2: JobMiddleware>
     let middleware2: Middleware2
 
     @inlinable
-    func onPushJob<Parameters: JobParameters>(parameters: Parameters, jobInstanceID: String) async {
-        await self.middleware1.onPushJob(parameters: parameters, jobInstanceID: jobInstanceID)
-        await self.middleware2.onPushJob(parameters: parameters, jobInstanceID: jobInstanceID)
+    func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
+        await self.middleware1.onPushJob(parameters: parameters, context: context)
+        await self.middleware2.onPushJob(parameters: parameters, context: context)
     }
     /// Job has been popped off the queue and decoded (with decode errors reported)
     @inlinable
-    func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, jobInstanceID: String) async {
-        await self.middleware1.onPopJob(result: result, jobInstanceID: jobInstanceID)
-        await self.middleware2.onPopJob(result: result, jobInstanceID: jobInstanceID)
+    func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {
+        await self.middleware1.onPopJob(result: result, context: context)
+        await self.middleware2.onPopJob(result: result, context: context)
     }
     /// Process job and pass it onto next handler (works like middleware in Hummingbird)
     @inlinable
     func handleJob(
         job: any JobInstanceProtocol,
-        context: JobContext,
-        next: (any JobInstanceProtocol, JobContext) async throws -> Void
+        context: JobExecutionContext,
+        next: (any JobInstanceProtocol, JobExecutionContext) async throws -> Void
     ) async throws {
         try await self.middleware1.handleJob(job: job, context: context) { job, context in
             try await self.middleware2.handleJob(job: job, context: context, next: next)

--- a/Sources/Jobs/Middleware/JobMiddleware.swift
+++ b/Sources/Jobs/Middleware/JobMiddleware.swift
@@ -18,13 +18,13 @@ public protocol JobMiddleware: Sendable {
     ///
     /// - Parameters:
     ///   - parameters: Job parameters
-    ///   - jobInstanceID: Job instance identifier
+    ///   - jobID: Job instance identifier
     func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async
     /// Job has been popped off the queue and decoded (with decode errors reported)
     ///
     /// - Parameters:
     ///   - result: Result of popping the job from the queue (Either job instance or error)
-    ///   - jobInstanceID: Job instance identifer
+    ///   - jobID: Job instance identifer
     func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async
     /// Handle job and pass it onto next handler
     ///

--- a/Sources/Jobs/Middleware/MetricsMiddleware.swift
+++ b/Sources/Jobs/Middleware/MetricsMiddleware.swift
@@ -61,7 +61,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
     ///
     /// - Parameters:
     ///   - parameters: Job parameters
-    ///   - jobInstanceID: Job instance identifier
+    ///   - jobID: Job instance identifier
     @inlinable
     public func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
         Meter(
@@ -78,7 +78,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
     ///
     /// - Parameters:
     ///   - result: Result of popping the job from the queue (Either job instance or error)
-    ///   - jobInstanceID: Job instance identifer
+    ///   - jobID: Job instance identifer
     @inlinable
     public func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {
 

--- a/Sources/Jobs/Middleware/MetricsMiddleware.swift
+++ b/Sources/Jobs/Middleware/MetricsMiddleware.swift
@@ -23,7 +23,12 @@ import Foundation
 
 /// Add publishing of Metrics to a job queue
 public struct MetricsJobMiddleware: JobMiddleware {
-    public init() {}
+    @usableFromInline
+    let queueName: String
+
+    public init(queueName: String = "default") {
+        self.queueName = queueName
+    }
 
     /// Counter label
     @usableFromInline
@@ -58,12 +63,13 @@ public struct MetricsJobMiddleware: JobMiddleware {
     ///   - parameters: Job parameters
     ///   - jobInstanceID: Job instance identifier
     @inlinable
-    public func onPushJob<Parameters: JobParameters>(parameters: Parameters, jobInstanceID: String) async {
+    public func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
         Meter(
             label: Self.meterLabel,
             dimensions: [
                 ("status", JobStatus.queued.rawValue),
                 ("name", Parameters.jobName),
+                ("queue", self.queueName),
             ]
         ).increment()
     }
@@ -74,12 +80,13 @@ public struct MetricsJobMiddleware: JobMiddleware {
     ///   - result: Result of popping the job from the queue (Either job instance or error)
     ///   - jobInstanceID: Job instance identifer
     @inlinable
-    public func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, jobInstanceID: String) async {
+    public func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {
 
         switch result {
         case .failure(let error):
             var counterDimensions: [(String, String)] = [
-                ("reason", error.code.description)
+                ("reason", error.code.description),
+                ("queue", self.queueName),
             ]
 
             if let jobName = error.jobName {
@@ -90,6 +97,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
                     label: Self.meterLabel,
                     dimensions: [
                         ("status", JobStatus.queued.rawValue),
+                        ("queue", self.queueName),
                         jobNameDimension,
                     ]
                 ).decrement()
@@ -107,6 +115,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
                 dimensions: [
                     ("status", JobStatus.queued.rawValue),
                     ("name", job.name),
+                    ("queue", self.queueName),
                 ]
             ).decrement()
 
@@ -114,7 +123,10 @@ public struct MetricsJobMiddleware: JobMiddleware {
             let jobQueuedDuration = Date.now.timeIntervalSince(job.queuedAt)
             Timer(
                 label: Self.queuedTimerLabel,
-                dimensions: [("name", job.name)],
+                dimensions: [
+                    ("name", job.name),
+                    ("queue", self.queueName),
+                ],
                 preferredDisplayUnit: .seconds
             ).recordSeconds(jobQueuedDuration)
         }
@@ -130,8 +142,8 @@ public struct MetricsJobMiddleware: JobMiddleware {
     @inlinable
     public func handleJob(
         job: any JobInstanceProtocol,
-        context: JobContext,
-        next: (any JobInstanceProtocol, JobContext) async throws -> Void
+        context: JobExecutionContext,
+        next: (any JobInstanceProtocol, JobExecutionContext) async throws -> Void
     ) async throws {
         let startTime = DispatchTime.now().uptimeNanoseconds
         Meter(
@@ -139,6 +151,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
             dimensions: [
                 ("status", JobStatus.processing.rawValue),
                 ("name", job.name),
+                ("queue", self.queueName),
             ]
         ).increment()
         defer {
@@ -147,6 +160,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
                 dimensions: [
                     ("status", JobStatus.processing.rawValue),
                     ("name", job.name),
+                    ("queue", self.queueName),
                 ]
             ).decrement()
         }
@@ -176,6 +190,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
                     dimensions: [
                         ("status", JobStatus.queued.rawValue),
                         ("name", job.name),
+                        ("queue", self.queueName),
                     ]
                 ).increment()
 
@@ -207,7 +222,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
         if retrying {
             Counter(
                 label: Self.counterLabel,
-                dimensions: [("name", name), ("status", JobStatus.retried.rawValue)]
+                dimensions: [("name", name), ("status", JobStatus.retried.rawValue), ("queue", queueName)]
             ).increment()
             return
         }
@@ -226,6 +241,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
         let dimensions: [(String, String)] = [
             ("name", name),
             ("status", jobStatus.rawValue),
+            ("queue", queueName),
         ]
 
         // Calculate job execution time

--- a/Sources/Jobs/Middleware/TracingMiddleware.swift
+++ b/Sources/Jobs/Middleware/TracingMiddleware.swift
@@ -46,7 +46,7 @@ public struct TracingJobMiddleware: JobMiddleware {
                 span.addLink(.init(context: linkContext, attributes: .init()))
             }
             span.updateAttributes { attributes in
-                attributes["job.id"] = context.jobInstanceID
+                attributes["job.id"] = context.jobID
                 attributes["job.attempt"] = (job.attempts ?? 0) + 1
                 attributes["job.queue"] = self.queueName
             }

--- a/Tests/JobsTests/JobMiddlewareTests.swift
+++ b/Tests/JobsTests/JobMiddlewareTests.swift
@@ -32,18 +32,18 @@ final class JobMiddlewareTests: XCTestCase {
             self.handled = false
         }
 
-        func onPushJob<Parameters: JobParameters>(parameters: Parameters, jobInstanceID: String) async {
+        func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
             self.pushed = true
         }
 
-        func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, jobInstanceID: String) async {
+        func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {
             self.popped = true
         }
 
         func handleJob(
             job: any JobInstanceProtocol,
-            context: JobContext,
-            next: (any JobInstanceProtocol, JobContext) async throws -> Void
+            context: JobExecutionContext,
+            next: (any JobInstanceProtocol, JobExecutionContext) async throws -> Void
         ) async throws {
             self.handled = true
             try await next(job, context)
@@ -64,7 +64,7 @@ final class JobMiddlewareTests: XCTestCase {
             let nextScheduledAt: Date? = nil
             let traceContext: [String: String]? = nil
 
-            func execute(context: JobContext) async throws {}
+            func execute(context: JobExecutionContext) async throws {}
         }
         let observer1 = TestJobMiddleware()
         let observer2 = TestJobMiddleware()
@@ -73,10 +73,10 @@ final class JobMiddlewareTests: XCTestCase {
             TestJobMiddleware()
             observer2
         }
-        await observers.onPushJob(parameters: TestParameters(value: "test"), jobInstanceID: "0")
+        await observers.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobInstanceID: "0"))
         XCTAssertEqual(observer1.pushed, true)
         XCTAssertEqual(observer2.pushed, true)
-        await observers.onPopJob(result: .success(FakeJobInstance()), jobInstanceID: "0")
+        await observers.onPopJob(result: .success(FakeJobInstance()), context: .init(jobInstanceID: "0"))
         XCTAssertEqual(observer1.popped, true)
         XCTAssertEqual(observer2.popped, true)
         let job = FakeJobInstance()
@@ -109,7 +109,7 @@ final class JobMiddlewareTests: XCTestCase {
                 let traceContext: [String: String]? = nil
                 var nextScheduledAt: Date? = nil
 
-                func execute(context: JobContext) async throws {}
+                func execute(context: JobExecutionContext) async throws {}
             }
             let middleware1 = TestJobMiddleware()
             let middlewareChain = buildJobMiddleware {
@@ -117,9 +117,9 @@ final class JobMiddlewareTests: XCTestCase {
                     middleware1
                 }
             }
-            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), jobInstanceID: "0")
+            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobInstanceID: "0"))
             XCTAssertEqual(middleware1.pushed, first == true)
-            await middlewareChain.onPopJob(result: .success(FakeJobInstance()), jobInstanceID: "0")
+            await middlewareChain.onPopJob(result: .success(FakeJobInstance()), context: .init(jobInstanceID: "0"))
             XCTAssertEqual(middleware1.popped, first == true)
             let job = FakeJobInstance()
             try await middlewareChain.handleJob(
@@ -153,7 +153,7 @@ final class JobMiddlewareTests: XCTestCase {
                 let traceContext: [String: String]? = nil
                 let nextScheduledAt: Date? = Date.now
 
-                func execute(context: JobContext) async throws {}
+                func execute(context: JobExecutionContext) async throws {}
             }
             let middleware1 = TestJobMiddleware()
             let middleware2 = TestJobMiddleware()
@@ -164,10 +164,10 @@ final class JobMiddlewareTests: XCTestCase {
                     middleware2
                 }
             }
-            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), jobInstanceID: "0")
+            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobInstanceID: "0"))
             XCTAssertEqual(middleware1.pushed, first == true)
             XCTAssertEqual(middleware2.pushed, first != true)
-            await middlewareChain.onPopJob(result: .success(FakeJobInstance()), jobInstanceID: "0")
+            await middlewareChain.onPopJob(result: .success(FakeJobInstance()), context: .init(jobInstanceID: "0"))
             XCTAssertEqual(middleware1.popped, first == true)
             XCTAssertEqual(middleware2.popped, first != true)
             let job = FakeJobInstance()

--- a/Tests/JobsTests/JobMiddlewareTests.swift
+++ b/Tests/JobsTests/JobMiddlewareTests.swift
@@ -73,17 +73,17 @@ final class JobMiddlewareTests: XCTestCase {
             TestJobMiddleware()
             observer2
         }
-        await observers.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobInstanceID: "0"))
+        await observers.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobID: "0"))
         XCTAssertEqual(observer1.pushed, true)
         XCTAssertEqual(observer2.pushed, true)
-        await observers.onPopJob(result: .success(FakeJobInstance()), context: .init(jobInstanceID: "0"))
+        await observers.onPopJob(result: .success(FakeJobInstance()), context: .init(jobID: "0"))
         XCTAssertEqual(observer1.popped, true)
         XCTAssertEqual(observer2.popped, true)
         let job = FakeJobInstance()
         try await observers.handleJob(
             job: job,
             context: .init(
-                jobInstanceID: "0",
+                jobID: "0",
                 logger: .init(label: "Test"),
                 queuedAt: job.queuedAt,
                 nextScheduledAt: job.nextScheduledAt
@@ -117,15 +117,15 @@ final class JobMiddlewareTests: XCTestCase {
                     middleware1
                 }
             }
-            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobInstanceID: "0"))
+            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobID: "0"))
             XCTAssertEqual(middleware1.pushed, first == true)
-            await middlewareChain.onPopJob(result: .success(FakeJobInstance()), context: .init(jobInstanceID: "0"))
+            await middlewareChain.onPopJob(result: .success(FakeJobInstance()), context: .init(jobID: "0"))
             XCTAssertEqual(middleware1.popped, first == true)
             let job = FakeJobInstance()
             try await middlewareChain.handleJob(
                 job: job,
                 context: .init(
-                    jobInstanceID: "0",
+                    jobID: "0",
                     logger: .init(label: "Test"),
                     queuedAt: job.queuedAt,
                     nextScheduledAt: job.nextScheduledAt
@@ -164,17 +164,17 @@ final class JobMiddlewareTests: XCTestCase {
                     middleware2
                 }
             }
-            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobInstanceID: "0"))
+            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobID: "0"))
             XCTAssertEqual(middleware1.pushed, first == true)
             XCTAssertEqual(middleware2.pushed, first != true)
-            await middlewareChain.onPopJob(result: .success(FakeJobInstance()), context: .init(jobInstanceID: "0"))
+            await middlewareChain.onPopJob(result: .success(FakeJobInstance()), context: .init(jobID: "0"))
             XCTAssertEqual(middleware1.popped, first == true)
             XCTAssertEqual(middleware2.popped, first != true)
             let job = FakeJobInstance()
             try await middlewareChain.handleJob(
                 job: job,
                 context: .init(
-                    jobInstanceID: "0",
+                    jobID: "0",
                     logger: .init(label: "Test"),
                     queuedAt: job.queuedAt,
                     nextScheduledAt: job.nextScheduledAt

--- a/Tests/JobsTests/MetricsTests.swift
+++ b/Tests/JobsTests/MetricsTests.swift
@@ -480,12 +480,10 @@ final class MetricsTests: XCTestCase {
 
         let timer = try XCTUnwrap(Self.testMetrics.timers.withLockedValue { $0 }["swift.jobs.queued.duration"] as? TestTimer)
         XCTAssertGreaterThan(timer.values.withLockedValue { $0 }[0].1, 50_000_000)
-        XCTAssertEqual(timer.dimensions.count, 3)
+        XCTAssertEqual(timer.dimensions.count, 2)
         XCTAssertEqual(timer.dimensions[0].0, "name")
         XCTAssertEqual(timer.dimensions[0].1, "testJobQueuedTime")
-        XCTAssertEqual(timer.dimensions[1].0, "status")
-        XCTAssertEqual(timer.dimensions[1].1, "succeeded")
-        XCTAssertEqual(timer.dimensions[2].0, "queue")
-        XCTAssertEqual(timer.dimensions[2].1, "default")
+        XCTAssertEqual(timer.dimensions[1].0, "queue")
+        XCTAssertEqual(timer.dimensions[1].1, "default")
     }
 }

--- a/Tests/JobsTests/MetricsTests.swift
+++ b/Tests/JobsTests/MetricsTests.swift
@@ -281,7 +281,7 @@ final class MetricsTests: XCTestCase {
         let counter = try XCTUnwrap(Self.testMetrics.counters.withLockedValue { $0 }["swift.jobs"] as? TestCounter)
         XCTAssertEqual(counter.values.withLockedValue { $0 }[0].1, 1)
         XCTAssertEqual(counter.values.withLockedValue { $0 }.count, 1)  // This technically 5, need to figueout how to await the results to get 5
-        XCTAssertEqual(counter.dimensions.count, 2)
+        XCTAssertEqual(counter.dimensions.count, 3)
         XCTAssertEqual(counter.dimensions[0].0, "name")
         XCTAssertEqual(counter.dimensions[0].1, "testDispatchJobCounter")
         XCTAssertEqual(counter.dimensions[1].0, "status")
@@ -292,11 +292,13 @@ final class MetricsTests: XCTestCase {
 
         let processingMeter = try XCTUnwrap(Self.testMetrics.meters.withLockedValue { $0 }["swift.jobs.meter"] as? TestMeter)
         XCTAssertEqual(processingMeter.values.withLockedValue { $0 }.count, 1)
-        XCTAssertEqual(processingMeter.dimensions.count, 2)
+        XCTAssertEqual(processingMeter.dimensions.count, 3)
         XCTAssertEqual(processingMeter.dimensions[0].0, "status")
         XCTAssertEqual(processingMeter.dimensions[0].1, "processing")
         XCTAssertEqual(processingMeter.dimensions[1].0, "name")
         XCTAssertEqual(processingMeter.dimensions[1].1, TestParameters.jobName)
+        XCTAssertEqual(processingMeter.dimensions[2].0, "queue")
+        XCTAssertEqual(processingMeter.dimensions[2].1, "default")
     }
 
     func testFailToDecode() async throws {
@@ -328,11 +330,13 @@ final class MetricsTests: XCTestCase {
         }
 
         let discardedCounter = try XCTUnwrap(Self.testMetrics.counters.withLockedValue { $0 }["swift.jobs.discarded"] as? TestCounter)
-        XCTAssertEqual(discardedCounter.dimensions.count, 2)
+        XCTAssertEqual(discardedCounter.dimensions.count, 3)
         XCTAssertEqual(discardedCounter.dimensions[0].0, "reason")
         XCTAssertEqual(discardedCounter.dimensions[0].1, "decodeJobFailed")
-        XCTAssertEqual(discardedCounter.dimensions[1].0, "name")
-        XCTAssertEqual(discardedCounter.dimensions[1].1, "testFailToDecode")
+        XCTAssertEqual(discardedCounter.dimensions[1].0, "queue")
+        XCTAssertEqual(discardedCounter.dimensions[1].1, "default")
+        XCTAssertEqual(discardedCounter.dimensions[2].0, "name")
+        XCTAssertEqual(discardedCounter.dimensions[2].1, "testFailToDecode")
     }
 
     func testErrorRetryAndThenSucceed() async throws {
@@ -445,10 +449,13 @@ final class MetricsTests: XCTestCase {
 
         let timer = try XCTUnwrap(Self.testMetrics.timers.withLockedValue { $0 }["swift.jobs.duration"] as? TestTimer)
         XCTAssertGreaterThan(timer.values.withLockedValue { $0 }[0].1, 5_000_000)
+        XCTAssertEqual(timer.dimensions.count, 3)
         XCTAssertEqual(timer.dimensions[0].0, "name")
         XCTAssertEqual(timer.dimensions[0].1, "testJobExecutionTime")
         XCTAssertEqual(timer.dimensions[1].0, "status")
         XCTAssertEqual(timer.dimensions[1].1, "succeeded")
+        XCTAssertEqual(timer.dimensions[2].0, "queue")
+        XCTAssertEqual(timer.dimensions[2].1, "default")
     }
 
     func testJobQueuedTime() async throws {
@@ -473,5 +480,12 @@ final class MetricsTests: XCTestCase {
 
         let timer = try XCTUnwrap(Self.testMetrics.timers.withLockedValue { $0 }["swift.jobs.queued.duration"] as? TestTimer)
         XCTAssertGreaterThan(timer.values.withLockedValue { $0 }[0].1, 50_000_000)
+        XCTAssertEqual(timer.dimensions.count, 3)
+        XCTAssertEqual(timer.dimensions[0].0, "name")
+        XCTAssertEqual(timer.dimensions[0].1, "testJobQueuedTime")
+        XCTAssertEqual(timer.dimensions[1].0, "status")
+        XCTAssertEqual(timer.dimensions[1].1, "succeeded")
+        XCTAssertEqual(timer.dimensions[2].0, "queue")
+        XCTAssertEqual(timer.dimensions[2].1, "default")
     }
 }

--- a/Tests/JobsTests/TracingTests.swift
+++ b/Tests/JobsTests/TracingTests.swift
@@ -62,6 +62,7 @@ final class TracingTests: XCTestCase {
             [
                 "job.id": "\(jobID.uuidString)",
                 "job.attempt": 1,
+                "job.queue": "default",
             ]
         )
     }
@@ -115,6 +116,7 @@ final class TracingTests: XCTestCase {
             [
                 "job.id": "\(jobID.uuidString)",
                 "job.attempt": 1,
+                "job.queue": "default",
             ]
         )
         let span2 = try XCTUnwrap(tracer.spans.last)
@@ -143,7 +145,7 @@ final class TracingTests: XCTestCase {
         InstrumentationSystem.bootstrapInternal(tracer)
 
         let jobQueue = JobQueue(.memory, numWorkers: 1, logger: Logger(label: "JobsTests")) {
-            TracingJobMiddleware()
+            TracingJobMiddleware(queueName: "tracing")
         }
         jobQueue.registerJob(parameters: TestParameters.self) { parameters, context in
             context.logger.info("Parameters=\(parameters)")
@@ -184,6 +186,7 @@ final class TracingTests: XCTestCase {
             [
                 "job.id": "\(jobID.uuidString)",
                 "job.attempt": 1,
+                "job.queue": "tracing",
             ]
         )
     }


### PR DESCRIPTION
- Renamed JobContext to JobExecutionContext
- Added JobQueueContext for jobs being added/removed from queue
- Initially I added the job queue name to both of these contexts, but decided it seems a little stupid passing this values around all the time when it never changed.
- So I have gone with initialising the Metrics and Tracing middlewares with a queueName, defaulting it to "default"