### PR TITLE
Replace single lastScheduledDate metadata with multiple

### DIFF
--- a/Sources/Jobs/Middleware/JobMiddleware.swift
+++ b/Sources/Jobs/Middleware/JobMiddleware.swift
@@ -18,19 +18,19 @@ public protocol JobMiddleware: Sendable {
     ///
     /// - Parameters:
     ///   - parameters: Job parameters
-    ///   - jobID: Job instance identifier
+    ///   - context: Job queue context
     func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async
     /// Job has been popped off the queue and decoded (with decode errors reported)
     ///
     /// - Parameters:
     ///   - result: Result of popping the job from the queue (Either job instance or error)
-    ///   - jobID: Job instance identifer
+    ///   - context: Job queue context
     func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async
     /// Handle job and pass it onto next handler
     ///
     /// - Parameters:
     ///   - job: Job instance
-    ///   - context: Job context
+    ///   - context: Job execution context
     ///   - next: Next handler
     /// - Throws:
     func handleJob(

--- a/Sources/Jobs/Middleware/MetricsMiddleware.swift
+++ b/Sources/Jobs/Middleware/MetricsMiddleware.swift
@@ -61,7 +61,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
     ///
     /// - Parameters:
     ///   - parameters: Job parameters
-    ///   - jobID: Job instance identifier
+    ///   - context: Job queue context
     @inlinable
     public func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
         Meter(
@@ -78,7 +78,7 @@ public struct MetricsJobMiddleware: JobMiddleware {
     ///
     /// - Parameters:
     ///   - result: Result of popping the job from the queue (Either job instance or error)
-    ///   - jobID: Job instance identifer
+    ///   - context: Job queue context
     @inlinable
     public func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {
 

--- a/Tests/JobsTests/TracingTests.swift
+++ b/Tests/JobsTests/TracingTests.swift
@@ -34,7 +34,9 @@ final class TracingTests: XCTestCase {
         }
         let expectation = expectation(description: "Expected span to be ended.")
         let tracer = TestTracer()
-        tracer.onEndSpan = { _ in expectation.fulfill() }
+        tracer.onEndSpan = { _ in
+            expectation.fulfill()
+        }
         InstrumentationSystem.bootstrapInternal(tracer)
 
         let jobQueue = JobQueue(.memory, numWorkers: 1, logger: Logger(label: "JobsTests")) {


### PR DESCRIPTION
Store a last scheduled date metadata for each job. This means the state of one job schedule is not affected by the state of another. 

This fixes an issue where two jobs are scheduled at the same time but the scheduler goes down inbetween scheduling the two of them. When the scheduler is brought back up it will either add the first job into the queue again or not add the second.