### PR TITLE
Add JobQueueOptions.gracefulShutdownTimeout

### DIFF
--- a/Sources/Jobs/JobQueueHandler.swift
+++ b/Sources/Jobs/JobQueueHandler.swift
@@ -58,11 +58,10 @@ final class JobQueueHandler<Queue: JobQueueDriver>: Sendable {
                     }
                 }
 
-                if let gracefulShutdownTimeout = self.options.gracefulShutdownTimeout {
-                    group.addTask {
-                        await stream.first { _ in true }
-                        try await Task.sleep(for: gracefulShutdownTimeout)
-                    }
+                group.addTask {
+                    // wait until graceful shutdown or cancellation has been triggered
+                    await stream.first { _ in true }
+                    try await Task.sleep(for: self.options.gracefulShutdownTimeout)
                 }
                 // wait on first child task to return. If the first task to return is the queue handler then
                 // cancel timeout task. If the first child task to return is the timeout task then cancel the

--- a/Sources/Jobs/JobQueueOptions.swift
+++ b/Sources/Jobs/JobQueueOptions.swift
@@ -20,10 +20,21 @@ import Foundation
 
 /// JobQueueOptions
 public struct JobQueueOptions: Sendable {
+    /// Default job retry strategy for the job queue
     let retryStrategy: JobRetryStrategy
+    /// Timeout after graceful shutdown has been triggered, before jobs are cancelled
+    let gracefulShutdownTimeout: Duration?
 
     /// Initialize a JobQueueOptions
-    public init(defaultRetryStrategy: any JobRetryStrategy = .exponentialJitter()) {
+    ///
+    /// - Parameters:
+    ///   - defaultRetryStrategy: Default job retry strategy for the job queue
+    ///   - gracefulShutdownTimeout: Timeout after graceful shutdown has been triggered, before jobs are cancelled
+    public init(
+        defaultRetryStrategy: any JobRetryStrategy = .exponentialJitter(),
+        gracefulShutdownTimeout: Duration? = nil
+    ) {
         self.retryStrategy = defaultRetryStrategy
+        self.gracefulShutdownTimeout = gracefulShutdownTimeout
     }
 }

--- a/Sources/Jobs/JobQueueOptions.swift
+++ b/Sources/Jobs/JobQueueOptions.swift
@@ -23,7 +23,7 @@ public struct JobQueueOptions: Sendable {
     /// Default job retry strategy for the job queue
     let retryStrategy: JobRetryStrategy
     /// Timeout after graceful shutdown has been triggered, before jobs are cancelled
-    let gracefulShutdownTimeout: Duration?
+    let gracefulShutdownTimeout: Duration
 
     /// Initialize a JobQueueOptions
     ///
@@ -32,7 +32,7 @@ public struct JobQueueOptions: Sendable {
     ///   - gracefulShutdownTimeout: Timeout after graceful shutdown has been triggered, before jobs are cancelled
     public init(
         defaultRetryStrategy: any JobRetryStrategy = .exponentialJitter(),
-        gracefulShutdownTimeout: Duration? = nil
+        gracefulShutdownTimeout: Duration = .seconds(30)
     ) {
         self.retryStrategy = defaultRetryStrategy
         self.gracefulShutdownTimeout = gracefulShutdownTimeout

--- a/Sources/Jobs/Utils/DecodableWithUserInfoConfiguration.swift
+++ b/Sources/Jobs/Utils/DecodableWithUserInfoConfiguration.swift
@@ -52,7 +52,7 @@ extension JSONDecoder {
         _ type: T.Type,
         from buffer: ByteBuffer,
         userInfoConfiguration: T.DecodingConfiguration
-    ) throws -> T where T: DecodableWithUserInfoConfiguration {
+    ) throws -> T where T: DecodableWithUserInfoConfiguration, T.DecodingConfiguration: Sendable {
         self.userInfo[._jobConfiguration] = userInfoConfiguration
         return try self.decode(type, from: buffer)
     }

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -570,4 +570,59 @@ final class JobsTests: XCTestCase {
         }
         XCTAssertEqual(jobRunSequence.withLockedValue { $0 }, [30, 15])
     }
+
+    func testJobQueueGracefulShutdownWaitsForJob() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "testJobTimeout"
+        }
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 1)
+        var logger = Logger(label: "JobsTests")
+        logger.logLevel = .trace
+        let jobQueue = JobQueue(
+            .memory,
+            logger: logger,
+            options: .init(gracefulShutdownTimeout: nil)
+        )
+        jobQueue.registerJob(
+            parameters: TestParameters.self,
+            retryStrategy: .dontRetry
+        ) { _, _ in
+            try await Task.sleep(for: .milliseconds(100))
+            expectation.fulfill()
+        }
+        try await testJobQueue(jobQueue) {
+            _ = try await jobQueue.push(TestParameters())
+        }
+        await fulfillment(of: [expectation], timeout: 5)
+    }
+
+    func testJobQueueGracefulShutdownTimeout() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "testJobTimeout"
+        }
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 1)
+        let failedJobCount = ManagedAtomic(0)
+        var logger = Logger(label: "JobsTests")
+        logger.logLevel = .trace
+        let jobQueue = JobQueue(
+            MemoryQueue { _, error in
+                XCTAssert(error is CancellationError)
+                failedJobCount.wrappingIncrement(by: 1, ordering: .relaxed)
+            },
+            logger: logger,
+            options: .init(gracefulShutdownTimeout: .milliseconds(50))
+        )
+        jobQueue.registerJob(
+            parameters: TestParameters.self,
+            retryStrategy: .dontRetry
+        ) { _, _ in
+            expectation.fulfill()
+            try await Task.sleep(for: .seconds(10))
+        }
+        try await testJobQueue(jobQueue) {
+            try await jobQueue.push(TestParameters())
+            await fulfillment(of: [expectation], timeout: 5)
+        }
+        XCTAssertEqual(failedJobCount.load(ordering: .relaxed), 1)
+    }
 }

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -582,7 +582,7 @@ final class JobsTests: XCTestCase {
         let jobQueue = JobQueue(
             .memory,
             logger: logger,
-            options: .init(gracefulShutdownTimeout: nil)
+            options: .init(gracefulShutdownTimeout: .seconds(10000))
         )
         jobQueue.registerJob(
             parameters: TestParameters.self,


### PR DESCRIPTION
If this timeout triggers after graceful shutdown has been triggered, then all the currently processing jobs are cancelled. 