### PR TITLE
Adding leader election capability

### DIFF
--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -56,6 +56,8 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == JobQueu
     func getMetadata(_ key: String) async throws -> ByteBuffer?
     /// set job queue metadata
     func setMetadata(key: String, value: ByteBuffer) async throws
+    /// check if driver an instace is the leader
+    func isLeader() async throws -> Bool
 }
 
 extension JobQueueDriver {

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -56,8 +56,10 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == JobQueu
     func getMetadata(_ key: String) async throws -> ByteBuffer?
     /// set job queue metadata
     func setMetadata(key: String, value: ByteBuffer) async throws
-    /// check if driver an instace is the leader
+    /// check if current work  is the leader
     func isLeader() async -> Bool
+    /// leadership election
+    func electLeaderShip() async throws
 }
 
 extension JobQueueDriver {

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -57,7 +57,7 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == JobQueu
     /// set job queue metadata
     func setMetadata(key: String, value: ByteBuffer) async throws
     /// check if driver an instace is the leader
-    func isLeader() async throws -> Bool
+    func isLeader() async -> Bool
 }
 
 extension JobQueueDriver {

--- a/Sources/Jobs/Leadership/LeadershipElectorService.swift
+++ b/Sources/Jobs/Leadership/LeadershipElectorService.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import ServiceLifecycle
+
+public struct LeadershipElectorService<Driver: JobQueueDriver>: Service, CustomStringConvertible {
+    private let jobQueue: JobQueue<Driver>
+    private let interval: Duration
+
+    public init(jobQueue: JobQueue<Driver>, interval: Duration = .seconds(10)) {
+        self.jobQueue = jobQueue
+        self.interval = interval
+    }
+
+    public func run() async throws {
+        try await jobQueue.initializationComplete.waitUntilTriggered()
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                while !Task.isShuttingDownGracefully {
+                    try await jobQueue.queue.electLeaderShip()
+
+                    try await Task.sleep(for: interval)
+                }
+            }
+            try await group.waitForAll()
+        }
+    }
+
+    public var description: String {
+        "LeadershipElectorService(\(String(describing: jobQueue)))"
+    }
+}

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -124,7 +124,7 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
         await self.queue.isLeader
     }
 
-    public func electeAsLeader() async {
+    public func electLeaderShip() async {
         await self.queue.setLeadership()
     }
 
@@ -228,10 +228,6 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
 
         func setLeadership() {
             self.isLeader = true
-        }
-
-        func resetLeadership() {
-            self.isLeader = false
         }
     }
 }

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -120,16 +120,12 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
         await self.queue.setMetadata(key: key, value: value)
     }
 
-    public func isLeader() async throws -> Bool {
+    public func isLeader() async -> Bool {
         await self.queue.isLeader
     }
 
     public func electeAsLeader() async {
         await self.queue.setLeadership()
-    }
-
-    public func resetLeadership() async {
-        await self.queue.resetLeadership()
     }
 
     /// Internal actor managing the job queue

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -120,6 +120,18 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
         await self.queue.setMetadata(key: key, value: value)
     }
 
+    public func isLeader() async throws -> Bool {
+        await self.queue.isLeader
+    }
+
+    public func electeAsLeader() async {
+        await self.queue.setLeadership()
+    }
+
+    public func resetLeadership() async {
+        await self.queue.resetLeadership()
+    }
+
     /// Internal actor managing the job queue
     fileprivate actor Internal {
         struct QueuedJob: Sendable {
@@ -130,6 +142,7 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
         var pendingJobs: [JobID: ByteBuffer]
         var metadata: [String: ByteBuffer]
         var isStopped: Bool
+        var isLeader: Bool = false
 
         init() {
             self.queue = .init()
@@ -215,6 +228,14 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
 
         func setMetadata(key: String, value: NIOCore.ByteBuffer) {
             self.metadata[key] = value
+        }
+
+        func setLeadership() {
+            self.isLeader = true
+        }
+
+        func resetLeadership() {
+            self.isLeader = false
         }
     }
 }

--- a/Sources/Jobs/Scheduler/JobSchedule.swift
+++ b/Sources/Jobs/Scheduler/JobSchedule.swift
@@ -252,18 +252,21 @@ public struct JobSchedule: MutableCollection, Sendable {
             )
             for await job in scheduledJobSequence.cancelOnGracefulShutdown() {
                 do {
-                    
+
                     let willSchedule = try await jobQueue.queue.isLeader()
 
                     guard willSchedule else {
-                        jobQueue.logger.debug("Not the leader, skipping job scheduling.", metadata: [
-                            "job": "\(type(of: job.job).jobName)",
-                            "currentScheduledAt": "\(String(describing: job.date))",
-                            "nextScheduledAt": "\(String(describing: job.nextScheduledAt))"
-                        ])
+                        jobQueue.logger.debug(
+                            "Not the leader, skipping job scheduling.",
+                            metadata: [
+                                "job": "\(type(of: job.job).jobName)",
+                                "currentScheduledAt": "\(String(describing: job.date))",
+                                "nextScheduledAt": "\(String(describing: job.nextScheduledAt))",
+                            ]
+                        )
                         continue
                     }
-            
+
                     _ = try await job.job.push(
                         to: self.jobQueue,
                         currentSchedule: job.date,

--- a/Sources/Jobs/Scheduler/JobSchedule.swift
+++ b/Sources/Jobs/Scheduler/JobSchedule.swift
@@ -252,6 +252,18 @@ public struct JobSchedule: MutableCollection, Sendable {
             )
             for await job in scheduledJobSequence.cancelOnGracefulShutdown() {
                 do {
+                    
+                    let willSchedule = try await jobQueue.queue.isLeader()
+
+                    guard willSchedule else {
+                        jobQueue.logger.debug("Not the leader, skipping job scheduling.", metadata: [
+                            "job": "\(type(of: job.job).jobName)",
+                            "currentScheduledAt": "\(String(describing: job.date))",
+                            "nextScheduledAt": "\(String(describing: job.nextScheduledAt))"
+                        ])
+                        continue
+                    }
+            
                     _ = try await job.job.push(
                         to: self.jobQueue,
                         currentSchedule: job.date,

--- a/Sources/Jobs/Scheduler/JobSchedule.swift
+++ b/Sources/Jobs/Scheduler/JobSchedule.swift
@@ -253,7 +253,7 @@ public struct JobSchedule: MutableCollection, Sendable {
             for await job in scheduledJobSequence.cancelOnGracefulShutdown() {
                 do {
 
-                    let willSchedule = try await jobQueue.queue.isLeader()
+                    let willSchedule = await jobQueue.queue.isLeader()
 
                     guard willSchedule else {
                         jobQueue.logger.debug(

--- a/Tests/JobsTests/JobSchedulerTests.swift
+++ b/Tests/JobsTests/JobSchedulerTests.swift
@@ -485,10 +485,10 @@ final class JobSchedulerTests: XCTestCase {
 
         var logger = Logger(label: "jobs")
         logger.logLevel = .debug
-        
+
         let memoryStorage = MemoryQueue()
         await memoryStorage.electeAsLeader()
-        
+
         let jobQueue = JobQueue(memoryStorage, logger: logger)
         jobQueue.registerJob(parameters: TriggerShutdownParameters.self) { _, context in
             source.yield()
@@ -568,7 +568,7 @@ final class JobSchedulerTests: XCTestCase {
 
     func testMultipleSchedulerServicesWithJustOneAbleToScheduled() async throws {
         let (stream, source) = AsyncStream.makeStream(of: Int.self)
-        
+
         struct LeadershipParameters: JobParameters {
             static let jobName = "LeadershipJob"
         }

--- a/Tests/JobsTests/JobSchedulerTests.swift
+++ b/Tests/JobsTests/JobSchedulerTests.swift
@@ -447,8 +447,10 @@ final class JobSchedulerTests: XCTestCase {
 
         var logger = Logger(label: "jobs")
         logger.logLevel = .debug
+        let memoryStorage = MemoryQueue()
+        await memoryStorage.electeAsLeader()
 
-        let jobQueue = JobQueue(MemoryQueue(), logger: logger)
+        let jobQueue = JobQueue(memoryStorage, logger: logger)
         jobQueue.registerJob(parameters: TriggerShutdownParameters.self) { _, context in
             XCTAssertNotNil(context.nextScheduledAt)
             XCTAssertGreaterThan(context.nextScheduledAt!, context.queuedAt)
@@ -483,8 +485,11 @@ final class JobSchedulerTests: XCTestCase {
 
         var logger = Logger(label: "jobs")
         logger.logLevel = .debug
-
-        let jobQueue = JobQueue(MemoryQueue(), logger: logger)
+        
+        let memoryStorage = MemoryQueue()
+        await memoryStorage.electeAsLeader()
+        
+        let jobQueue = JobQueue(memoryStorage, logger: logger)
         jobQueue.registerJob(parameters: TriggerShutdownParameters.self) { _, context in
             source.yield()
         }
@@ -523,7 +528,10 @@ final class JobSchedulerTests: XCTestCase {
         var logger = Logger(label: "jobs")
         logger.logLevel = .debug
 
-        let jobQueue = JobQueue(MemoryQueue(), logger: logger)
+        let memoryStorage = MemoryQueue()
+        await memoryStorage.electeAsLeader()
+
+        let jobQueue = JobQueue(memoryStorage, logger: logger)
         jobQueue.registerJob(parameters: TriggerShutdownParameters.self) { _, _ in
             source.yield()
         }
@@ -556,6 +564,60 @@ final class JobSchedulerTests: XCTestCase {
         let lastDate = try await jobQueue.getMetadata(.jobScheduleLastDate(schedulerName: "testLastDateAccuracy", jobName: "TriggerShutdown"))
         let lastDate2 = try XCTUnwrap(lastDate)
         XCTAssertEqual(lastDate2.timeIntervalSince1970, dateTriggered.timeIntervalSince1970, accuracy: 1.0)
+    }
+
+    func testMultipleSchedulerServicesWithJustOneAbleToScheduled() async throws {
+        let (stream, source) = AsyncStream.makeStream(of: Int.self)
+        
+        struct LeadershipParameters: JobParameters {
+            static let jobName = "LeadershipJob"
+        }
+
+        var logger = Logger(label: "jobs")
+        logger.logLevel = .debug
+        let memoryStorage = MemoryQueue()
+        await memoryStorage.electeAsLeader()
+
+        let jobQueue = JobQueue(memoryStorage, logger: logger)
+        let jobQueue2 = JobQueue(MemoryQueue(), logger: logger)
+        jobQueue.registerJob(parameters: LeadershipParameters.self) { _, context in
+            XCTAssertNotNil(context.nextScheduledAt)
+            XCTAssertGreaterThan(context.nextScheduledAt!, context.queuedAt)
+
+            source.yield(1)
+        }
+        // job queue 2 will never run because it's not the leader
+        // what's the best way to test this?
+        jobQueue2.registerJob(parameters: LeadershipParameters.self) { _, context in
+            XCTAssertNotNil(context.nextScheduledAt)
+            XCTAssertGreaterThan(context.nextScheduledAt!, context.queuedAt)
+            context.logger.debug("Hello from second queue")
+        }
+        // create schedule that ensures a job will be run in the next second
+        let dateComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: Date.now + 1)
+        var jobSchedule = JobSchedule()
+        jobSchedule.addJob(LeadershipParameters(), schedule: .everyMinute(second: dateComponents.second!))
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            let serviceGroup = await ServiceGroup(
+                configuration: .init(
+                    services: [
+                        jobQueue,
+                        jobQueue2,
+                        jobSchedule.scheduler(on: jobQueue),
+                        jobSchedule.scheduler(on: jobQueue2),
+                    ],
+                    logger: logger
+                )
+            )
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            let one = await stream.first { _ in true }
+            XCTAssertEqual(one, 1)
+            await serviceGroup.triggerGracefulShutdown()
+        }
     }
 }
 

--- a/Tests/JobsTests/LeadershipElectorServiceTests.swift
+++ b/Tests/JobsTests/LeadershipElectorServiceTests.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2024 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import ServiceLifecycle
+import XCTest
+
+@testable import Jobs
+
+final class LeadershipElectorServiceTests: XCTestCase {
+    func testMultipleSchedulerServicesWithJustOneAbleToScheduled() async throws {
+        let (stream, source) = AsyncStream.makeStream(of: Int.self)
+
+        struct LeadershipParameters: JobParameters {
+            static let jobName = "LeadershipJob"
+        }
+
+        var logger = Logger(label: "jobs")
+        logger.logLevel = .debug
+
+        let jobQueue = JobQueue(MemoryQueue(), logger: logger)
+        let jobQueue2 = JobQueue(MemoryQueue(), logger: logger)
+        jobQueue.registerJob(parameters: LeadershipParameters.self) { _, context in
+            XCTAssertNotNil(context.nextScheduledAt)
+            XCTAssertGreaterThan(context.nextScheduledAt!, context.queuedAt)
+
+            source.yield(1)
+        }
+        // job queue 2 will never run because it's not the leader
+        // what's the best way to test this?
+        jobQueue2.registerJob(parameters: LeadershipParameters.self) { _, context in
+            XCTAssertNotNil(context.nextScheduledAt)
+            XCTAssertGreaterThan(context.nextScheduledAt!, context.queuedAt)
+            context.logger.debug("Hello from second queue")
+        }
+        // create schedule that ensures a job will be run in the next second
+        let dateComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: Date.now + 1)
+        var jobSchedule = JobSchedule()
+        jobSchedule.addJob(LeadershipParameters(), schedule: .everyMinute(second: dateComponents.second!))
+
+        let elector = LeadershipElectorService(jobQueue: jobQueue, interval: .milliseconds(100))
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            let serviceGroup = await ServiceGroup(
+                configuration: .init(
+                    services: [
+                        jobQueue,
+                        jobQueue2,
+                        jobSchedule.scheduler(on: jobQueue),
+                        jobSchedule.scheduler(on: jobQueue2),
+                        elector,
+                    ],
+                    logger: logger
+                )
+            )
+            group.addTask {
+                try await serviceGroup.run()
+                let firstNodeIsLeader = await jobQueue.queue.isLeader()
+                XCTAssertTrue(firstNodeIsLeader)
+                let isLeader = await jobQueue2.queue.isLeader()
+                XCTAssertFalse(isLeader)
+            }
+            let one = await stream.first { _ in true }
+            XCTAssertEqual(one, 1)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+}


### PR DESCRIPTION
* Only leader should be able to schedule jobs to prevent one job from being scheduled multiple times
* The memory driver is a little bit complicated since we don't have a global state store.