### PR TITLE
Resurrect separation of job name and parameters

### DIFF
--- a/Sources/Jobs/JobName.swift
+++ b/Sources/Jobs/JobName.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2021-2025 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public struct JobName<Parameters: Codable>: CustomStringConvertible, ExpressibleByStringLiteral, Sendable, Equatable {
+    public let name: String
+
+    public init(_ string: String, parameters: Parameters.Type = Parameters.self) {
+        self.name = string
+    }
+
+    public init(stringLiteral string: String) {
+        self.name = string
+    }
+
+    public var description: String {
+        self.name
+    }
+}
+
+public struct Job<Parameters: Codable> {
+    let name: JobName<Parameters>
+    let parameters: Parameters
+
+    public init(name: JobName<Parameters>, parameters: Parameters) {
+        self.name = name
+        self.parameters = parameters
+    }
+
+    public init(parameters: Parameters) where Parameters: JobParameters {
+        self.name = Parameters.jobNameIdentifier
+        self.parameters = parameters
+    }
+}

--- a/Sources/Jobs/JobName.swift
+++ b/Sources/Jobs/JobName.swift
@@ -27,18 +27,3 @@ public struct JobName<Parameters: Codable>: CustomStringConvertible, Expressible
         self.name
     }
 }
-
-public struct Job<Parameters: Codable> {
-    let name: JobName<Parameters>
-    let parameters: Parameters
-
-    public init(name: JobName<Parameters>, parameters: Parameters) {
-        self.name = name
-        self.parameters = parameters
-    }
-
-    public init(parameters: Parameters) where Parameters: JobParameters {
-        self.name = Parameters.jobNameIdentifier
-        self.parameters = parameters
-    }
-}

--- a/Sources/Jobs/JobParameters.swift
+++ b/Sources/Jobs/JobParameters.swift
@@ -25,13 +25,6 @@ public protocol JobParameters: Codable, Sendable {
 }
 
 extension JobParameters {
-    // Job name identifier
-    public static var jobNameIdentifier: JobName<Self> {
-        .init(jobName)
-    }
-}
-
-extension JobParameters {
     /// Added so it's possible for the scheduler to add date partitions
     internal func push<Queue: JobQueueDriver>(
         to jobQueue: JobQueue<Queue>,

--- a/Sources/Jobs/JobParameters.swift
+++ b/Sources/Jobs/JobParameters.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Hummingbird server framework project
 //
-// Copyright (c) 2021-2024 the Hummingbird authors
+// Copyright (c) 2021-2025 the Hummingbird authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -22,6 +22,13 @@ import Foundation
 public protocol JobParameters: Codable, Sendable {
     /// Job type name
     static var jobName: String { get }
+}
+
+extension JobParameters {
+    // Job name identifier
+    public static var jobNameIdentifier: JobName<Self> {
+        .init(jobName)
+    }
 }
 
 extension JobParameters {

--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -57,7 +57,7 @@ extension JobQueueProtocol {
     @discardableResult public func push<Parameters: JobParameters>(
         _ parameters: Parameters
     ) async throws -> Queue.JobID {
-        try await self.push(Parameters.jobNameIdentifier, parameters: parameters, options: .init())
+        try await self.push(.init(Parameters.jobName), parameters: parameters, options: .init())
     }
 
     ///  Push Job onto queue
@@ -68,7 +68,7 @@ extension JobQueueProtocol {
         _ parameters: Parameters,
         options: Queue.JobOptions
     ) async throws -> Queue.JobID {
-        try await self.push(Parameters.jobNameIdentifier, parameters: parameters, options: options)
+        try await self.push(.init(Parameters.jobName), parameters: parameters, options: options)
     }
 
     ///  Push Job onto queue

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -31,19 +31,19 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == JobQueu
     /// Called when JobQueueHandler is initialised with this queue
     func onInit() async throws
     /// Register job definition with driver
-    func registerJob<Parameters: JobParameters>(_ job: JobDefinition<Parameters>)
+    func registerJob<Parameters: Sendable & Codable>(_ job: JobDefinition<Parameters>)
     /// Push Job onto queue
     /// - Parameters
     ///   - jobRequest: Job Request
     ///   - options: JobOptions
     /// - Returns: Identifier of queued jobs
-    @discardableResult func push<Parameters: JobParameters>(_ jobRequest: JobRequest<Parameters>, options: JobOptions) async throws -> JobID
+    @discardableResult func push<Parameters>(_ jobRequest: JobRequest<Parameters>, options: JobOptions) async throws -> JobID
     /// Retry an existing Job
     /// - Parameters
     ///   - id: Job instance ID
     ///   - jobRequest: Job Request
     ///   - options: JobOptions
-    func retry<Parameters: JobParameters>(_ id: JobID, jobRequest: JobRequest<Parameters>, options: JobRetryOptions) async throws
+    func retry<Parameters>(_ id: JobID, jobRequest: JobRequest<Parameters>, options: JobRetryOptions) async throws
     /// This is called to say job has finished processing and it can be deleted
     func finished(jobID: JobID) async throws
     /// This is called to say job has failed to run and should be put aside
@@ -65,7 +65,7 @@ extension JobQueueDriver {
 
 extension JobQueueDriver {
     func retry(_ jobID: JobID, job: some JobInstanceProtocol, attempt: Int, options: JobRetryOptions) async throws {
-        let jobRequest = JobRequest(parameters: job.parameters, queuedAt: job.queuedAt, attempt: attempt)
+        let jobRequest = JobRequest(name: job.name, parameters: job.parameters, queuedAt: job.queuedAt, attempt: attempt)
         return try await self.retry(jobID, jobRequest: jobRequest, options: options)
     }
 }

--- a/Sources/Jobs/JobRegistry.swift
+++ b/Sources/Jobs/JobRegistry.swift
@@ -50,14 +50,14 @@ public final class JobRegistry: Sendable {
     ///  Register job
     /// - Parameters:
     ///   - job: Job Definition
-    public func registerJob<Parameters: JobParameters>(_ job: JobDefinition<Parameters>) {
+    public func registerJob<Parameters>(_ job: JobDefinition<Parameters>) {
         let builder: @Sendable (Decoder) throws -> any JobInstanceProtocol = { decoder in
             let data = try JobInstanceData<Parameters>(from: decoder)
             return try JobInstance<Parameters>(job: job, data: data)
         }
         self.builderTypeMap.withLockedValue {
-            precondition($0[Parameters.jobName] == nil, "There is a job already registered under name \"\(Parameters.jobName)\"")
-            $0[Parameters.jobName] = builder
+            precondition($0[job.name] == nil, "There is a job already registered under name \"\(job.name)\"")
+            $0[job.name] = builder
         }
     }
 

--- a/Sources/Jobs/JobRequest.swift
+++ b/Sources/Jobs/JobRequest.swift
@@ -19,16 +19,20 @@ import Foundation
 #endif
 
 /// Request to run job, pushed to job queue
-public struct JobRequest<Parameters: JobParameters>: Encodable {
+public struct JobRequest<Parameters: Sendable & Codable>: Encodable {
+    /// Job name
+    public let name: String
     /// Job details
     public let data: JobInstanceData<Parameters>
 
     init(
+        name: String,
         parameters: Parameters,
         queuedAt: Date,
         attempt: Int,
         nextScheduledAt: Date? = nil
     ) {
+        self.name = name
         self.data = .init(
             parameters: parameters,
             queuedAt: queuedAt,
@@ -38,6 +42,7 @@ public struct JobRequest<Parameters: JobParameters>: Encodable {
     }
 
     init(jobInstance: JobInstance<Parameters>, attempt: Int) {
+        self.name = .init(jobInstance.name)
         self.data = .init(
             parameters: jobInstance.parameters,
             queuedAt: jobInstance.queuedAt,
@@ -48,7 +53,7 @@ public struct JobRequest<Parameters: JobParameters>: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: _JobCodingKey.self)
         let childEncoder = container.superEncoder(
-            forKey: .init(stringValue: Parameters.jobName, intValue: nil)
+            forKey: .init(stringValue: name, intValue: nil)
         )
         try self.data.encode(to: childEncoder)
     }

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -65,7 +65,7 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
     ///  Register job
     /// - Parameters:
     ///   - job: Job Definition
-    public func registerJob<Parameters: JobParameters>(_ job: JobDefinition<Parameters>) {
+    public func registerJob<Parameters>(_ job: JobDefinition<Parameters>) {
         self.jobRegistry.registerJob(job)
     }
 
@@ -74,7 +74,7 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
     ///   - jobRequest: Job Request
     ///   - options: Job options
     /// - Returns: Job ID
-    @discardableResult public func push<Parameters: JobParameters>(_ jobRequest: JobRequest<Parameters>, options: JobOptions) async throws -> JobID {
+    @discardableResult public func push<Parameters>(_ jobRequest: JobRequest<Parameters>, options: JobOptions) async throws -> JobID {
         let buffer = try self.jobRegistry.encode(jobRequest: jobRequest)
         return try await self.queue.push(buffer, options: options)
     }
@@ -84,7 +84,7 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
     ///   - id: Job ID
     ///   - jobRequest: Job Request
     ///   - options: Job options
-    public func retry<Parameters: JobParameters>(_ id: JobID, jobRequest: JobRequest<Parameters>, options: JobRetryOptions) async throws {
+    public func retry<Parameters>(_ id: JobID, jobRequest: JobRequest<Parameters>, options: JobRetryOptions) async throws {
         let buffer = try self.jobRegistry.encode(jobRequest: jobRequest)
         let options = JobOptions(delayUntil: options.delayUntil)
         try await self.queue.retry(id, buffer: buffer, options: options)

--- a/Sources/Jobs/Middleware/JobMiddleware.swift
+++ b/Sources/Jobs/Middleware/JobMiddleware.swift
@@ -19,7 +19,7 @@ public protocol JobMiddleware: Sendable {
     /// - Parameters:
     ///   - parameters: Job parameters
     ///   - context: Job queue context
-    func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async
+    func onPushJob<Parameters>(name: String, parameters: Parameters, context: JobQueueContext) async
     /// Job has been popped off the queue and decoded (with decode errors reported)
     ///
     /// - Parameters:
@@ -46,7 +46,7 @@ public struct NullJobMiddleware: JobMiddleware {
 
     /// Job has been pushed onto the queue
     @inlinable
-    public func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {}
+    public func onPushJob<Parameters>(name: String, parameters: Parameters, context: JobQueueContext) async {}
     /// Job has been popped off the queue and decoded (with decode errors reported)
     @inlinable
     public func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {}
@@ -66,9 +66,9 @@ struct OptionalJobMiddleware<Middleware: JobMiddleware>: JobMiddleware {
     let middleware: Middleware?
 
     @inlinable
-    func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
+    func onPushJob<Parameters>(name: String, parameters: Parameters, context: JobQueueContext) async {
         if let middleware {
-            await middleware.onPushJob(parameters: parameters, context: context)
+            await middleware.onPushJob(name: name, parameters: parameters, context: context)
         }
     }
     /// Job has been popped off the queue and decoded (with decode errors reported)
@@ -99,9 +99,9 @@ struct TwoJobMiddlewares<Middleware1: JobMiddleware, Middleware2: JobMiddleware>
     let middleware2: Middleware2
 
     @inlinable
-    func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
-        await self.middleware1.onPushJob(parameters: parameters, context: context)
-        await self.middleware2.onPushJob(parameters: parameters, context: context)
+    func onPushJob<Parameters>(name: String, parameters: Parameters, context: JobQueueContext) async {
+        await self.middleware1.onPushJob(name: name, parameters: parameters, context: context)
+        await self.middleware2.onPushJob(name: name, parameters: parameters, context: context)
     }
     /// Job has been popped off the queue and decoded (with decode errors reported)
     @inlinable

--- a/Sources/Jobs/Middleware/MetricsMiddleware.swift
+++ b/Sources/Jobs/Middleware/MetricsMiddleware.swift
@@ -63,12 +63,12 @@ public struct MetricsJobMiddleware: JobMiddleware {
     ///   - parameters: Job parameters
     ///   - context: Job queue context
     @inlinable
-    public func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
+    public func onPushJob<Parameters>(name: String, parameters: Parameters, context: JobQueueContext) async {
         Meter(
             label: Self.meterLabel,
             dimensions: [
                 ("status", JobStatus.queued.rawValue),
-                ("name", Parameters.jobName),
+                ("name", name),
                 ("queue", self.queueName),
             ]
         ).increment()

--- a/Sources/Jobs/Middleware/TracingMiddleware.swift
+++ b/Sources/Jobs/Middleware/TracingMiddleware.swift
@@ -30,7 +30,7 @@ public struct TracingJobMiddleware: JobMiddleware {
     }
 
     @inlinable
-    public func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {}
+    public func onPushJob<Parameters>(name: String, parameters: Parameters, context: JobQueueContext) async {}
     @inlinable
     public func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {}
 

--- a/Tests/JobsTests/JobMiddlewareTests.swift
+++ b/Tests/JobsTests/JobMiddlewareTests.swift
@@ -32,7 +32,7 @@ final class JobMiddlewareTests: XCTestCase {
             self.handled = false
         }
 
-        func onPushJob<Parameters: JobParameters>(parameters: Parameters, context: JobQueueContext) async {
+        func onPushJob<Parameters>(name: String, parameters: Parameters, context: JobQueueContext) async {
             self.pushed = true
         }
 
@@ -74,7 +74,7 @@ final class JobMiddlewareTests: XCTestCase {
             TestJobMiddleware()
             observer2
         }
-        await observers.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobID: "0"))
+        await observers.onPushJob(name: "testResultBuilderWithTwoMiddleware", parameters: "test", context: .init(jobID: "0"))
         XCTAssertEqual(observer1.pushed, true)
         XCTAssertEqual(observer2.pushed, true)
         await observers.onPopJob(result: .success(FakeJobInstance()), context: .init(jobID: "0"))
@@ -120,7 +120,11 @@ final class JobMiddlewareTests: XCTestCase {
                     middleware1
                 }
             }
-            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobID: "0"))
+            await middlewareChain.onPushJob(
+                name: "testResultBuildeOptionalMiddleware",
+                parameters: TestParameters(value: "test"),
+                context: .init(jobID: "0")
+            )
             XCTAssertEqual(middleware1.pushed, first == true)
             await middlewareChain.onPopJob(result: .success(FakeJobInstance()), context: .init(jobID: "0"))
             XCTAssertEqual(middleware1.popped, first == true)
@@ -169,7 +173,11 @@ final class JobMiddlewareTests: XCTestCase {
                     middleware2
                 }
             }
-            await middlewareChain.onPushJob(parameters: TestParameters(value: "test"), context: .init(jobID: "0"))
+            await middlewareChain.onPushJob(
+                name: "testResultBuilderIfElseMiddleware",
+                parameters: TestParameters(value: "test"),
+                context: .init(jobID: "0")
+            )
             XCTAssertEqual(middleware1.pushed, first == true)
             XCTAssertEqual(middleware2.pushed, first != true)
             await middlewareChain.onPopJob(result: .success(FakeJobInstance()), context: .init(jobID: "0"))

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -58,10 +58,6 @@ final class JobsTests: XCTestCase {
     }
 
     func testJobNameBasic() async throws {
-        struct TestParameters: JobParameters {
-            static let jobName = "testBasic"
-            let value: Int
-        }
         let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 6)
         let jobQueue = JobQueue(.memory, numWorkers: 1, logger: Logger(label: "JobsTests"))
         let jobName = JobName<Int>("testJobNameBasic")

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -57,6 +57,32 @@ final class JobsTests: XCTestCase {
         }
     }
 
+    func testJobNameBasic() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "testBasic"
+            let value: Int
+        }
+        let expectation = XCTestExpectation(description: "TestJob.execute was called", expectedFulfillmentCount: 6)
+        let jobQueue = JobQueue(.memory, numWorkers: 1, logger: Logger(label: "JobsTests"))
+        let jobName = JobName<Int>("testJobNameBasic")
+        let job = JobDefinition(name: jobName) { parameters, context in
+            context.logger.info("Parameters=\(parameters)")
+            try await Task.sleep(for: .milliseconds(Int.random(in: 10..<50)))
+            expectation.fulfill()
+        }
+        jobQueue.registerJob(job)
+        try await testJobQueue(jobQueue) {
+            try await jobQueue.push(jobName, parameters: 1)
+            try await jobQueue.push(jobName, parameters: 2)
+            try await jobQueue.push(jobName, parameters: 3)
+            try await jobQueue.push(jobName, parameters: 4)
+            try await jobQueue.push(jobName, parameters: 5)
+            try await jobQueue.push(jobName, parameters: 6)
+
+            await fulfillment(of: [expectation], timeout: 5)
+        }
+    }
+
     func testMultipleWorkers() async throws {
         struct TestParameters: JobParameters {
             static let jobName = "testMultipleWorkers"


### PR DESCRIPTION
- Added JobName type which associates a job name with its parameters.
- Add functions that take JobName and Parameters which don't require Parameters to conform to JobParameters
- Remove all requirements that Parameters have to conform to `JobParameters` and replace with conformance to `Sendable & Codable`