### PR TITLE
Add option to lock scheduler to one node

### DIFF
--- a/Sources/Jobs/JobQueueProcessor.swift
+++ b/Sources/Jobs/JobQueueProcessor.swift
@@ -240,3 +240,9 @@ extension Date {
         return Date(timeIntervalSinceReferenceDate: timeValue)
     }
 }
+
+extension TimeInterval {
+    init(duration: Duration) {
+        self = Double(duration.components.seconds) + Double(duration.components.attoseconds) / 1_000_000_000_000_000_000
+    }
+}

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -242,11 +242,11 @@ extension MemoryQueue: JobMetadataDriver {
         await self.queue.setMetadata(key: key, value: value)
     }
 
-    public func acquireMetadataLock(key: String, id: ByteBuffer, expiresIn: TimeInterval) async -> Bool {
+    public func acquireLock(key: String, id: ByteBuffer, expiresIn: TimeInterval) async -> Bool {
         await self.queue.acquireMetadataLock(key: key, id: id, expiresIn: expiresIn)
     }
 
-    public func releaseMetadataLock(key: String, id: ByteBuffer) async {
+    public func releaseLock(key: String, id: ByteBuffer) async {
         await self.queue.releaseMetadataLock(key: key, id: id)
     }
 }

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -22,7 +22,7 @@ import Foundation
 #endif
 
 /// In memory implementation of job queue driver. Stores job data in a circular buffer
-public final class MemoryQueue: JobQueueDriver, JobMetadataDriver, CancellableJobQueue, ResumableJobQueue {
+public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJobQueue {
     public typealias Element = JobQueueResult<JobID>
     public typealias JobID = UUID
     /// Job options
@@ -112,14 +112,6 @@ public final class MemoryQueue: JobQueueDriver, JobMetadataDriver, CancellableJo
         await self.queue.pauseJob(jobID: jobID)
     }
 
-    public func getMetadata(_ key: String) async -> ByteBuffer? {
-        await self.queue.getMetadata(key)
-    }
-
-    public func setMetadata(key: String, value: ByteBuffer) async {
-        await self.queue.setMetadata(key: key, value: value)
-    }
-
     /// Internal actor managing the job queue
     fileprivate actor Internal {
         struct QueuedJob: Sendable {
@@ -128,7 +120,7 @@ public final class MemoryQueue: JobQueueDriver, JobMetadataDriver, CancellableJo
         }
         var queue: Deque<(job: QueuedJob, options: JobOptions)>
         var pendingJobs: [JobID: ByteBuffer]
-        var metadata: [String: ByteBuffer]
+        var metadata: [String: (data: ByteBuffer, expires: ContinuousClock.Instant?)]
         var isStopped: Bool
 
         init() {
@@ -210,12 +202,50 @@ public final class MemoryQueue: JobQueueDriver, JobMetadataDriver, CancellableJo
         }
 
         func getMetadata(_ key: String) -> ByteBuffer? {
-            self.metadata[key]
+            self.metadata[key]?.data
         }
 
         func setMetadata(key: String, value: NIOCore.ByteBuffer) {
-            self.metadata[key] = value
+            self.metadata[key] = (data: value, expires: nil)
         }
+
+        func acquireMetadataLock(key: String, id: ByteBuffer, expiresIn: Duration) async -> Bool {
+            if self.metadata[key]?.data == id {
+                return true
+            } else if self.metadata[key] == nil {
+                self.metadata[key] = (data: id, expires: .now + expiresIn)
+                return true
+            } else if let expires = self.metadata[key]?.expires, expires < .now {
+                self.metadata[key] = (data: id, expires: .now + expiresIn)
+                return true
+            } else {
+                return false
+            }
+        }
+
+        func releaseMetadataLock(key: String, id: ByteBuffer) async {
+            if self.metadata[key]?.data == id {
+                self.metadata[key] = nil
+            }
+        }
+    }
+}
+
+extension MemoryQueue: JobMetadataDriver {
+    public func getMetadata(_ key: String) async -> ByteBuffer? {
+        await self.queue.getMetadata(key)
+    }
+
+    public func setMetadata(key: String, value: ByteBuffer) async {
+        await self.queue.setMetadata(key: key, value: value)
+    }
+
+    public func acquireMetadataLock(key: String, id: ByteBuffer, expiresIn: Duration) async -> Bool {
+        await self.queue.acquireMetadataLock(key: key, id: id, expiresIn: expiresIn)
+    }
+
+    public func releaseMetadataLock(key: String, id: ByteBuffer) async {
+        await self.queue.releaseMetadataLock(key: key, id: id)
     }
 }
 

--- a/Sources/Jobs/Metadata/JobMetadataDriver.swift
+++ b/Sources/Jobs/Metadata/JobMetadataDriver.swift
@@ -21,58 +21,109 @@ import Foundation
 #endif
 
 public protocol JobMetadataDriver {
-    /// get job queue metadata
+    /// Get JobQueue metadata
+    ///
+    /// - Parameter key: Metadata key
+    /// - Returns: Value associated with metadata key
     func getMetadata(_ key: String) async throws -> ByteBuffer?
-    /// set job queue metadata
+    /// Set JobQueue metadata
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - value: Value associated with metadata key
     func setMetadata(key: String, value: ByteBuffer) async throws
     /// Acquire metadata lock
-    func acquireMetadataLock(key: String, id: ByteBuffer, expiresIn: TimeInterval) async throws -> Bool
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - id: Lock identifier
+    ///   - expiresIn: When lock will expire
+    /// - Returns: If lock was acquired
+    func acquireLock(key: String, id: ByteBuffer, expiresIn: TimeInterval) async throws -> Bool
     /// Release metadata lock
-    func releaseMetadataLock(key: String, id: ByteBuffer) async throws
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - id: Lock identifier
+    func releaseLock(key: String, id: ByteBuffer) async throws
 }
 
 extension JobMetadataDriver {
     /// Get JobQueue metadata
+    ///
+    /// - Parameter key: Metadata key
+    /// - Returns: Value associated with metadata key
     func getMetadata<Value: Codable>(_ key: JobMetadataKey<Value>) async throws -> Value? {
         guard let buffer = try await self.getMetadata(key.name) else { return nil }
         return try JSONDecoder().decode(Value.self, from: buffer)
     }
 
     /// Set JobQueue metadata
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - value: Value associated with metadata key
     func setMetadata<Value: Codable>(key: JobMetadataKey<Value>, value: Value) async throws {
         let buffer = try JSONEncoder().encodeAsByteBuffer(value, allocator: ByteBufferAllocator())
         try await self.setMetadata(key: key.name, value: buffer)
     }
 
-    /// Acquire lock
-    func acquireMetadataLock<ID: Codable>(key: JobMetadataKey<ID>, id: ID, expiresIn: TimeInterval) async throws -> Bool {
+    /// Acquire metadata lock
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - id: Lock identifier
+    ///   - expiresIn: When lock will expire
+    /// - Returns: If lock was acquired
+    func acquireLock<ID: Codable>(key: JobMetadataKey<ID>, id: ID, expiresIn: TimeInterval) async throws -> Bool {
         let buffer = try JSONEncoder().encodeAsByteBuffer(id, allocator: ByteBufferAllocator())
-        return try await self.acquireMetadataLock(key: key.name, id: buffer, expiresIn: expiresIn)
+        return try await self.acquireLock(key: key.name, id: buffer, expiresIn: expiresIn)
     }
 
-    /// Release lock
-    func releaseMetadataLock<ID: Codable>(key: JobMetadataKey<ID>, id: ID) async throws {
+    /// Release metadata lock
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - id: Lock identifier
+    func releaseLock<ID: Codable>(key: JobMetadataKey<ID>, id: ID) async throws {
         let buffer = try JSONEncoder().encodeAsByteBuffer(id, allocator: ByteBufferAllocator())
-        try await self.releaseMetadataLock(key: key.name, id: buffer)
+        try await self.releaseLock(key: key.name, id: buffer)
     }
 
     /// Get JobQueue metadata
+    ///
+    /// - Parameter key: Metadata key
+    /// - Returns: Value associated with metadata key
     func getMetadata(_ key: JobMetadataKey<ByteBuffer>) async throws -> ByteBuffer? {
         try await self.getMetadata(key.name)
     }
 
     /// Set JobQueue metadata
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - value: Value associated with metadata key
     func setMetadata(key: JobMetadataKey<ByteBuffer>, value: ByteBuffer) async throws {
         try await self.setMetadata(key: key.name, value: value)
     }
 
-    /// Acquire lock
-    func acquireMetadataLock(key: JobMetadataKey<ByteBuffer>, id: ByteBuffer, expiresIn: TimeInterval) async throws -> Bool {
-        try await self.acquireMetadataLock(key: key.name, id: id, expiresIn: expiresIn)
+    /// Acquire metadata lock
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - id: Lock identifier
+    ///   - expiresIn: When lock will expire
+    /// - Returns: If lock was acquired
+    func acquireLock(key: JobMetadataKey<ByteBuffer>, id: ByteBuffer, expiresIn: TimeInterval) async throws -> Bool {
+        try await self.acquireLock(key: key.name, id: id, expiresIn: expiresIn)
     }
 
-    /// Release lock
-    func releaseMetadataLock(key: JobMetadataKey<ByteBuffer>, id: ByteBuffer) async throws {
-        try await self.releaseMetadataLock(key: key.name, id: id)
+    /// Release metadata lock
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - id: Lock identifier
+    func releaseLock(key: JobMetadataKey<ByteBuffer>, id: ByteBuffer) async throws {
+        try await self.releaseLock(key: key.name, id: id)
     }
 }

--- a/Sources/Jobs/Metadata/JobMetadataDriver.swift
+++ b/Sources/Jobs/Metadata/JobMetadataDriver.swift
@@ -76,5 +76,3 @@ extension JobMetadataDriver {
         try await self.releaseMetadataLock(key: key.name, id: id)
     }
 }
-
-typealias JobMetadataLock = JobMetadataKey<ByteBuffer>

--- a/Sources/Jobs/Metadata/JobMetadataDriver.swift
+++ b/Sources/Jobs/Metadata/JobMetadataDriver.swift
@@ -26,7 +26,7 @@ public protocol JobMetadataDriver {
     /// set job queue metadata
     func setMetadata(key: String, value: ByteBuffer) async throws
     /// Acquire metadata lock
-    func acquireMetadataLock(key: String, id: ByteBuffer, expiresIn: Duration) async throws -> Bool
+    func acquireMetadataLock(key: String, id: ByteBuffer, expiresIn: TimeInterval) async throws -> Bool
     /// Release metadata lock
     func releaseMetadataLock(key: String, id: ByteBuffer) async throws
 }
@@ -45,7 +45,7 @@ extension JobMetadataDriver {
     }
 
     /// Acquire lock
-    func acquireMetadataLock<ID: Codable>(key: JobMetadataKey<ID>, id: ID, expiresIn: Duration) async throws -> Bool {
+    func acquireMetadataLock<ID: Codable>(key: JobMetadataKey<ID>, id: ID, expiresIn: TimeInterval) async throws -> Bool {
         let buffer = try JSONEncoder().encodeAsByteBuffer(id, allocator: ByteBufferAllocator())
         return try await self.acquireMetadataLock(key: key.name, id: buffer, expiresIn: expiresIn)
     }
@@ -67,7 +67,7 @@ extension JobMetadataDriver {
     }
 
     /// Acquire lock
-    func acquireMetadataLock(key: JobMetadataKey<ByteBuffer>, id: ByteBuffer, expiresIn: Duration) async throws -> Bool {
+    func acquireMetadataLock(key: JobMetadataKey<ByteBuffer>, id: ByteBuffer, expiresIn: TimeInterval) async throws -> Bool {
         try await self.acquireMetadataLock(key: key.name, id: id, expiresIn: expiresIn)
     }
 

--- a/Sources/Jobs/Scheduler/JobSchedule.swift
+++ b/Sources/Jobs/Scheduler/JobSchedule.swift
@@ -415,7 +415,7 @@ public struct JobSchedule: MutableCollection, Sendable {
 
         private func acquireLock(_ lockID: ByteBuffer, expiresIn: TimeInterval) async -> Bool {
             do {
-                return try await self.jobQueue.queue.acquireMetadataLock(
+                return try await self.jobQueue.queue.acquireLock(
                     key: .jobSchedulerLock(schedulerName: self.name),
                     id: lockID,
                     expiresIn: expiresIn
@@ -427,7 +427,7 @@ public struct JobSchedule: MutableCollection, Sendable {
 
         private func releaseLock(_ lockID: ByteBuffer) async {
             do {
-                try await self.jobQueue.queue.releaseMetadataLock(
+                try await self.jobQueue.queue.releaseLock(
                     key: .jobSchedulerLock(schedulerName: self.name),
                     id: lockID
                 )

--- a/Sources/Jobs/Scheduler/JobSchedule.swift
+++ b/Sources/Jobs/Scheduler/JobSchedule.swift
@@ -180,9 +180,9 @@ public struct JobSchedule: MutableCollection, Sendable {
     public func scheduler<Queue: JobQueueDriver>(
         on jobQueue: JobQueue<Queue>,
         named name: String = "default",
-        jobOptions: Queue.JobOptions = .init()
+        options: Scheduler<Queue>.Options = .init()
     ) async -> Scheduler<Queue> {
-        await .init(named: name, jobQueue: jobQueue, jobOptions: jobOptions, jobSchedule: self)
+        await .init(named: name, jobQueue: jobQueue, options: options, jobSchedule: self)
     }
 
     func nextJob() -> (offset: Int, element: Element)? {
@@ -262,16 +262,53 @@ public struct JobSchedule: MutableCollection, Sendable {
 
     /// Job Scheduler Service
     public struct Scheduler<Driver: JobQueueDriver & JobMetadataDriver>: Service, CustomStringConvertible {
+        /// Defines how often if at all a lock should be acquired
+        public struct ExclusiveLock: Sendable {
+            enum Value: Sendable {
+                case ignore
+                case acquire(every: TimeInterval, for: TimeInterval)
+            }
+            let value: Value
+            /// Ignore lock
+            public static var ignore: Self { .init(value: .ignore) }
+            /// Acquire lock
+            /// - Parameters:
+            ///   - every: Frequency of acquiring the lock
+            ///   - for: How long the lock should be acquired for
+            public static func acquire(every: Duration, for: Duration) -> Self {
+                precondition(`for` > every, "The time between acquiring each lock shoud be less then the time you acquire the lock for.")
+                return .init(value: .acquire(every: .init(duration: every), for: .init(duration: `for`)))
+            }
+        }
+        /// Scheduler options
+        public struct Options: Sendable {
+            ///
+            let jobOptions: Driver.JobOptions
+            let schedulerLock: ExclusiveLock
+
+            ///  Initialize Scheduler Options
+            /// - Parameters:
+            ///   - jobOptions: Job options given to scheduled jobs
+            ///   - schedulerLock: Define how scheduler lock should be acquired if at all. If you have multiple scheduler
+            ///       processes you should set this to acquire a lock so one scheduler can be defined the primary
+            public init(
+                jobOptions: Driver.JobOptions = .init(),
+                schedulerLock: ExclusiveLock = .ignore
+            ) {
+                self.jobOptions = .init()
+                self.schedulerLock = schedulerLock
+            }
+        }
         let name: String
         let jobQueue: JobQueue<Driver>
         let jobSchedule: JobSchedule
-        let jobOptions: Driver.JobOptions
+        let options: Options
 
-        init(named name: String, jobQueue: JobQueue<Driver>, jobOptions: Driver.JobOptions, jobSchedule: JobSchedule) async {
+        init(named name: String, jobQueue: JobQueue<Driver>, options: Options, jobSchedule: JobSchedule) async {
             self.name = name
             self.jobQueue = jobQueue
             self.jobSchedule = jobSchedule
-            self.jobOptions = jobOptions
+            self.options = options
         }
 
         /// Run Job scheduler
@@ -281,20 +318,27 @@ public struct JobSchedule: MutableCollection, Sendable {
 
             try await self.jobQueue.queue.waitUntilReady()
 
-            while !Task.isShuttingDownGracefully, !Task.isCancelled {
-                guard await self.acquireLock(lockID, expiresIn: 20) else {
-                    self.jobQueue.logger.info("Failed to acquire scheduler lock")
-                    try? await cancelWhenGracefulShutdown {
-                        try await Task.sleep(for: .seconds(20))
+            /// If we are locking the scheduler to one process then attempt to acquire the lock
+            /// if it fails try again in later on
+            switch self.options.schedulerLock.value {
+            case .acquire(let every, let length):
+                while !Task.isShuttingDownGracefully, !Task.isCancelled {
+                    guard await self.acquireLock(lockID, expiresIn: length) else {
+                        self.jobQueue.logger.info("Failed to acquire scheduler lock")
+                        try? await cancelWhenGracefulShutdown {
+                            try await Task.sleep(for: .seconds(every))
+                        }
+                        continue
                     }
-                    continue
+                    self.jobQueue.logger.info("Scheduler running")
+                    await runScheduler(lockID)
                 }
-                self.jobQueue.logger.info("Scheduler running")
+                // Release lock so another process can pick up the scheduler
+                await self.releaseLock(lockID)
+
+            case .ignore:
                 await runScheduler(lockID)
             }
-
-            // Release lock so another process can pick up the scheduler
-            await self.releaseLock(lockID)
         }
 
         /// Run Job scheduler
@@ -318,25 +362,33 @@ public struct JobSchedule: MutableCollection, Sendable {
                 logger: self.jobQueue.logger
             )
             for job in scheduledJobSequence {
-                guard await self.acquireLock(lockID, expiresIn: 20) else {
-                    self.jobQueue.logger.info("Failed to acquire scheduler lock")
-                    break
-                }
-
                 do {
                     try await cancelWhenGracefulShutdown {
-                        while true {
-                            let timeInterval = job.date.timeIntervalSinceNow
-                            guard timeInterval > 10 else {
-                                if timeInterval > 0 {
-                                    try await Task.sleep(for: .seconds(timeInterval))
-                                }
-                                break
-                            }
-                            try await Task.sleep(for: .seconds(10))
-                            guard await self.acquireLock(lockID, expiresIn: 20) else {
+                        /// Wait until job is ready to schedule. Depending on if we are locking the scheduler
+                        /// acquire the scheduler lock every so often
+                        switch self.options.schedulerLock.value {
+                        case .ignore:
+                            try await Task.sleep(for: .seconds(job.date.timeIntervalSinceNow))
+
+                        case .acquire(let every, let length):
+                            guard await self.acquireLock(lockID, expiresIn: length) else {
                                 self.jobQueue.logger.info("Failed to acquire scheduler lock")
                                 break
+                            }
+
+                            while true {
+                                let timeInterval = job.date.timeIntervalSinceNow
+                                guard timeInterval > every else {
+                                    if timeInterval > 0 {
+                                        try await Task.sleep(for: .seconds(timeInterval))
+                                    }
+                                    break
+                                }
+                                try await Task.sleep(for: .seconds(every))
+                                guard await self.acquireLock(lockID, expiresIn: length) else {
+                                    self.jobQueue.logger.info("Failed to acquire scheduler lock")
+                                    break
+                                }
                             }
                         }
                     }
@@ -345,7 +397,7 @@ public struct JobSchedule: MutableCollection, Sendable {
                 }
                 do {
                     let request = job.element.createJobRequest(job.date, job.nextScheduledAt)
-                    _ = try await request.push(to: self.jobQueue, options: self.jobOptions)
+                    _ = try await request.push(to: self.jobQueue, options: self.options.jobOptions)
                     try await self.jobQueue.queue.setMetadata(
                         key: .jobScheduleLastDate(schedulerName: self.name, jobName: job.element.jobName),
                         value: job.date

--- a/Tests/JobsTests/JobSchedulerTests.swift
+++ b/Tests/JobsTests/JobSchedulerTests.swift
@@ -596,7 +596,11 @@ final class JobSchedulerTests: XCTestCase {
         await withThrowingTaskGroup(of: Void.self) { group in
             let serviceGroup = await ServiceGroup(
                 configuration: .init(
-                    services: [jobQueue.processor(), jobSchedule.scheduler(on: jobQueue), jobSchedule.scheduler(on: jobQueue)],
+                    services: [
+                        jobQueue.processor(),
+                        jobSchedule.scheduler(on: jobQueue, options: .init(schedulerLock: .acquire(every: .seconds(30), for: .seconds(40)))),
+                        jobSchedule.scheduler(on: jobQueue, options: .init(schedulerLock: .acquire(every: .seconds(30), for: .seconds(40)))),
+                    ],
                     logger: logger
                 )
             )

--- a/Tests/JobsTests/JobSchedulerTests.swift
+++ b/Tests/JobsTests/JobSchedulerTests.swift
@@ -275,10 +275,10 @@ final class JobSchedulerTests: XCTestCase {
             .init(job: Job2(), schedule: .everyMinute(second: (dateComponents.second! + 1) % 60)),
         ])
         let sequence = JobSchedule.JobSequence(jobSchedule: jobSchedule, logger: logger)
-        var jobIterator = sequence.makeAsyncIterator()
-        let job = await jobIterator.next()
+        var jobIterator = sequence.makeIterator()
+        let job = jobIterator.next()
         XCTAssertEqual(job?.element.jobName, "Job1")
-        let job2 = await jobIterator.next()
+        let job2 = jobIterator.next()
         XCTAssertEqual(job2?.element.jobName, "Job2")
     }
 
@@ -606,7 +606,6 @@ final class JobSchedulerTests: XCTestCase {
             await stream.first { _ in true }
             await serviceGroup.triggerGracefulShutdown()
         }
-
     }
 }
 


### PR DESCRIPTION
This requires drivers to supply a method of locking and releasing.

```swift
/// Acquire metadata lock
func acquireLock(key: String, id: ByteBuffer, expiresIn: TimeInterval) async throws -> Bool
/// Release metadata lock
func releaseLock(key: String, id: ByteBuffer) async throws
```

I also moved the wait in the JobSchedule sequence to the Scheduler