### PR TITLE
Re-org of middleware handling of errors

### DIFF
--- a/Sources/Jobs/JobContext.swift
+++ b/Sources/Jobs/JobContext.swift
@@ -37,7 +37,33 @@ public struct JobExecutionContext: Sendable {
 }
 
 /// context for job being adding/removed from queue
-public struct JobQueueContext {
+public struct JobPushQueueContext {
+    /// Job instance identifier
+    public let jobID: String
+    /// Attempt number for this job.
+    /// Starts at 1 and increments for every retry until max
+    public let attempt: Int
+
+    @usableFromInline
+    internal init(jobID: String, attempt: Int) {
+        self.jobID = jobID
+        self.attempt = attempt
+    }
+}
+
+/// context for job being adding/removed from queue
+public struct JobPopQueueContext {
+    /// Job instance identifier
+    public let jobID: String
+
+    @usableFromInline
+    internal init(jobID: String) {
+        self.jobID = jobID
+    }
+}
+
+/// context for job being adding/removed from queue
+public struct JobCompletedQueueContext {
     /// Job instance identifier
     public let jobID: String
 

--- a/Sources/Jobs/JobInstance.swift
+++ b/Sources/Jobs/JobInstance.swift
@@ -109,6 +109,7 @@ public struct JobInstanceData<Parameters: Sendable & Codable>: Codable, Sendable
     /// Time job was queued
     let queuedAt: Date
     /// Current attempt
+    @usableFromInline
     let attempt: Int
     /// trace context
     let traceContext: [String: String]?

--- a/Sources/Jobs/JobQueue.swift
+++ b/Sources/Jobs/JobQueue.swift
@@ -212,7 +212,7 @@ public struct JobQueue<Queue: JobQueueDriver>: JobQueueProtocol, Sendable {
         await self.middleware.onPushJob(
             name: jobRequest.name,
             parameters: jobRequest.data.parameters,
-            context: .init(jobID: instanceID.description)
+            context: .init(jobID: instanceID.description, attempt: jobRequest.data.attempt)
         )
         self.logger.debug(
             "Pushed Job",

--- a/Sources/Jobs/Middleware/TracingMiddleware.swift
+++ b/Sources/Jobs/Middleware/TracingMiddleware.swift
@@ -29,11 +29,13 @@ public struct TracingJobMiddleware: JobMiddleware {
         self.queueName = queueName
     }
 
-    @inlinable
-    public func onPushJob<Parameters>(name: String, parameters: Parameters, context: JobQueueContext) async {}
-    @inlinable
-    public func onPopJob(result: Result<any JobInstanceProtocol, JobQueueError>, context: JobQueueContext) async {}
-
+    /// Setup tracing span and pass it onto next handler, recording success or erro into the span
+    ///
+    /// - Parameters:
+    ///   - job: Job instance
+    ///   - context: Job execution context
+    ///   - next: Next handler
+    /// - Throws:
     @inlinable
     public func handleJob(
         job: any JobInstanceProtocol,

--- a/Tests/JobsTests/MetricsTests.swift
+++ b/Tests/JobsTests/MetricsTests.swift
@@ -425,9 +425,6 @@ final class MetricsTests: XCTestCase {
         XCTAssertEqual(meter.values.withLockedValue { $0 }[0].1, 0)
         XCTAssertEqual(meter.dimensions[0].0, "status")
         XCTAssertEqual(meter.dimensions[0].1, "processing")
-        let timer = try XCTUnwrap(Self.testMetrics.timers.withLockedValue { $0 }["swift.jobs.duration"] as? TestTimer)
-        XCTAssertEqual(timer.dimensions[1].0, "status")
-        XCTAssertEqual(timer.dimensions[1].1, "failed")
     }
 
     func testJobExecutionTime() async throws {


### PR DESCRIPTION
This is mainly to make it easier to catch events like retrying or when a job is push to the failed queue. Previously we had to call shouldRetry to verify if a job was going to be failed or retried. This would mean the function would get called repeatedly.

- Added OnCompletedJob
- Added attempt to onPushJob and call it when we retry
- Use onCompletedJob in metrics middleware

This should make it easier to write middleware that responds to events 