### PR TITLE
Job sleep error

### DIFF
--- a/Sources/Jobs/JobQueueProcessor.swift
+++ b/Sources/Jobs/JobQueueProcessor.swift
@@ -183,6 +183,30 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
                 }.value
                 await self.middleware.onCompletedJob(job: job, result: .failure(error), context: .init(jobID: jobID.description))
                 return
+            } catch let error as JobSleepError {
+                logger.debug("Job: sleeping")
+                /// retry the current job
+                try await self.queue.retry(
+                    jobID,
+                    job: job,
+                    attempt: job.attempt,
+                    options: .init(delayUntil: error.until)
+                )
+                /// Call onPushJob as job has been added to the queue again
+                await self.middleware.onPushJob(
+                    name: job.name,
+                    parameters: job.parameters,
+                    context: .init(jobID: jobID.description, attempt: job.attempt)
+                )
+
+                logger.debug(
+                    "Retrying Job",
+                    metadata: [
+                        "JobName": .string(job.name),
+                        "attempt": .stringConvertible(job.attempt),
+                        "delayedUntil": .stringConvertible(error.until),
+                    ]
+                )
             } catch {
                 if !job.shouldRetry(error: error) {
                     logger.debug("Job: failed")
@@ -212,7 +236,6 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
                 logger.debug(
                     "Retrying Job",
                     metadata: [
-                        "JobID": .stringConvertible(jobID),
                         "JobName": .string(job.name),
                         "attempt": .stringConvertible(attempt),
                         "delayedUntil": .stringConvertible(delayUntil),

--- a/Sources/Jobs/JobQueueProcessor.swift
+++ b/Sources/Jobs/JobQueueProcessor.swift
@@ -183,14 +183,15 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
                 }.value
                 await self.middleware.onCompletedJob(job: job, result: .failure(error), context: .init(jobID: jobID.description))
                 return
-            } catch let error as JobSleepError {
+            } catch let error as JobSleep {
                 logger.debug("Job: sleeping")
+                let attempt = error.attemptAction.updateAttempt(job.attempt)
                 /// retry the current job
                 try await self.queue.retry(
                     jobID,
                     job: job,
-                    attempt: job.attempt,
-                    options: .init(delayUntil: error.until)
+                    attempt: attempt,
+                    options: .init(delayUntil: error.delayUntil)
                 )
                 /// Call onPushJob as job has been added to the queue again
                 await self.middleware.onPushJob(
@@ -203,8 +204,8 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
                     "Retrying Job",
                     metadata: [
                         "JobName": .string(job.name),
-                        "attempt": .stringConvertible(job.attempt),
-                        "delayedUntil": .stringConvertible(error.until),
+                        "attempt": .stringConvertible(attempt),
+                        "delayedUntil": .stringConvertible(error.delayUntil),
                     ]
                 )
             } catch {

--- a/Sources/Jobs/JobSleep.swift
+++ b/Sources/Jobs/JobSleep.swift
@@ -11,24 +11,56 @@ import FoundationEssentials
 import Foundation
 #endif
 
-struct JobSleepError: Error {
-    let until: Date
-}
+/// Error used to implement custom retry implementations
+///
+/// When a job throws this error the JobQueueProcessor recognises it and
+/// will delay retrying of the job until the date specified. It will allows
+/// control over the attempt count is updated.
+///
+/// This can be used in situations where a resource is not ready for a job
+/// and we want to delay until that resource is available
+public struct JobSleep: Error {
+    public struct AttemptAction: Sendable {
+        enum Action {
+            case doNothing
+            case reset
+            case increment
+        }
+        let action: Action
 
-extension JobQueue {
-    /// Quit job and retry after specified period
-    ///
-    /// Throws an error that is caught by the job queue processor.
-    /// - Parameter delay: How long to wait before retrying job
-    public static func sleep(for delay: Duration) throws {
-        throw JobSleepError(until: Date.now._advanced(by: delay))
+        /// Don't increment job attempts
+        public static var doNothing: Self { .init(action: .doNothing) }
+        /// Reset job attempts to the first attempt
+        public static var reset: Self { .init(action: .reset) }
+        /// Increment job attemtps
+        public static var increment: Self { .init(action: .increment) }
+
+        func updateAttempt(_ attempt: Int) -> Int {
+            switch self.action {
+            case .doNothing: attempt
+            case .increment: attempt + 1
+            case .reset: 1
+            }
+        }
+    }
+    let delayUntil: Date
+    let attemptAction: AttemptAction
+
+    ///  Initialize JobSleep
+    /// - Parameters:
+    ///   - delayUntil: How long we should wait until before queuing job again
+    ///   - attempts: How we should update the attempt number
+    public init(until: Date, attempts: AttemptAction = .doNothing) {
+        self.delayUntil = until
+        self.attemptAction = attempts
     }
 
-    ///  Quit job and retry at specified date
-    ///
-    /// Throws an error that is caught by the job queue processor
-    /// - Parameter date: How long to wait until before retrying job
-    public static func sleep(until date: Date) throws {
-        throw JobSleepError(until: date)
+    ///  Initialize JobSleep
+    /// - Parameters:
+    ///   - duration: How long we should wait before queuing job again
+    ///   - attempts: How we should update the attempt number
+    public init(for duration: Duration, attempts: AttemptAction = .doNothing) {
+        self.delayUntil = Date.now._advanced(by: duration)
+        self.attemptAction = attempts
     }
 }

--- a/Sources/Jobs/JobSleep.swift
+++ b/Sources/Jobs/JobSleep.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+struct JobSleepError: Error {
+    let until: Date
+}
+
+extension JobQueue {
+    /// Quit job and retry after specified period
+    ///
+    /// Throws an error that is caught by the job queue processor.
+    /// - Parameter delay: How long to wait before retrying job
+    public static func sleep(for delay: Duration) throws {
+        throw JobSleepError(until: Date.now._advanced(by: delay))
+    }
+
+    ///  Quit job and retry at specified date
+    ///
+    /// Throws an error that is caught by the job queue processor
+    /// - Parameter date: How long to wait until before retrying job
+    public static func sleep(until date: Date) throws {
+        throw JobSleepError(until: date)
+    }
+}

--- a/Sources/Jobs/JobSleep.swift
+++ b/Sources/Jobs/JobSleep.swift
@@ -6,9 +6,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 #if canImport(FoundationEssentials)
-import FoundationEssentials
+public import FoundationEssentials
 #else
-import Foundation
+public import Foundation
 #endif
 
 /// Error used to implement custom retry implementations

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -693,11 +693,11 @@ struct JobsTests {
         var logger = Logger(label: "testJobSleep")
         logger.logLevel = .debug
         let jobQueue = JobQueue(.memory, logger: logger)
-        let delayedJob = ManagedAtomic(0)
+        let delayedJob = Atomic(0)
         let delayUntil = Date(timeIntervalSinceNow: 1.0)
         let (stream, cont) = AsyncStream.makeStream(of: Void.self)
         jobQueue.registerJob(parameters: TestParameters.self) { parameters, context in
-            if delayedJob.loadThenWrappingIncrement(ordering: .relaxed) == 0 {
+            if delayedJob.add(1, ordering: .relaxed).oldValue == 0 {
                 #expect(Date.now < delayUntil)
                 throw JobSleep(until: delayUntil)
             }

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -685,4 +685,28 @@ struct JobsTests {
         )
         #expect(acquired == true)
     }
+
+    @Test func testJobSleep() async throws {
+        struct TestParameters: JobParameters, Equatable {
+            static let jobName = "testJobSleep"
+        }
+        var logger = Logger(label: "testJobSleep")
+        logger.logLevel = .debug
+        let jobQueue = JobQueue(.memory, logger: logger)
+        let delayedJob = ManagedAtomic(0)
+        let delayUntil = Date(timeIntervalSinceNow: 1.0)
+        let (stream, cont) = AsyncStream.makeStream(of: Void.self)
+        jobQueue.registerJob(parameters: TestParameters.self) { parameters, context in
+            if delayedJob.loadThenWrappingIncrement(ordering: .relaxed) == 0 {
+                #expect(Date.now < delayUntil)
+                throw JobSleep(until: delayUntil)
+            }
+            #expect(Date.now > delayUntil)
+            cont.yield()
+        }
+        try await testJobQueue(jobQueue.processor()) {
+            try await jobQueue.push(TestParameters())
+            await stream.first { _ in true }
+        }
+    }
 }


### PR DESCRIPTION
Custom error that will cause JobQueueProcessor to re-queue a job at a user defined time

```swift
jobQueue.registerJob(parameters: MyJob.self) { parameters, context in
    guard let resource = getResource(parameters.resource) else {
        // resource isn't ready lets sleep for an hour
        throw JobSleep(for: .seconds(60*60))
    }
    try await processResource(resource)
}
```