### PR TITLE
Add JobService that combines all of the components of swift-jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Job queue for processing workloads asynchronously across multiple nodes.
 
 ```swift
 // create job queue stored in local memory, that can run four jobs concurrently
-let jobQueue = JobQueue(
+let jobService = JobService(
     .memory, 
     logger: logger
 )
@@ -39,7 +39,7 @@ struct SendEmailJobParameters: JobParameters {
     let body: String
 }
 // Register jobs with job queue
-jobQueue.registerJob(parameters: SendEmailJobParameters.self) { parameters, context in
+jobService.registerJob(parameters: SendEmailJobParameters.self) { parameters, context in
     try await myEmailService.sendEmail(
         to: parameters.to, 
         subject: parameters.subject, 
@@ -47,21 +47,21 @@ jobQueue.registerJob(parameters: SendEmailJobParameters.self) { parameters, cont
     )
 }
 // Push instance of job onto queue
-jobQueue.push(SendEmailJobParameters(
+jobService.push(SendEmailJobParameters(
     to: "Ellen", 
     subject:"Hello", 
     body: "Hi there!"
 ))
 ```
 
-## Process Jobs
+## Processing Jobs
 
-You can create a `JobQueueProcessor` to process jobs added to yout `JobQueue`. `JobQueueProcessor` conforms to `Service` and can be used with `ServiceGroup` from `ServiceLifecycle`.
+`JobService` conforms to `Service` and can be used with `ServiceGroup` from `ServiceLifecycle`. Internally this will create a `JobQueueProcessor` to process jobs added to your `JobService`
 
 ```swift
 let serviceGroup = ServiceGroup(
     configuration: .init(
-        services: [jobQueue.processor(options: .init(numWorkers: 4))],
+        services: [jobService],
         gracefulShutdownSignals: [.sigterm, .sigint],
         logger: Logger(label: "JobQueueService")
     )
@@ -72,10 +72,20 @@ try await serviceGroup.run()
 Or it can be added as a service attached to a Hummingbird application
 
 ```swift
-let app = Application(router: router, services: [jobQueue.processor(options: .init(numWorkers: 4))])
+let app = Application(router: router, services: [jobService])
 ```
 
-When the `JobQueueProcessor` service is running it processes jobs as they appear on the queue. The `numWorkers` field in the options initializer indicates how many jobs it will run concurrently.
+When the `JobQueueProcessor` service is running it executes jobs as they appear on the queue. The `numWorkers` field in the options initializer indicates how many jobs it will run concurrently.
+
+## Scheduling Jobs
+
+`JobService` also include a job scheduler that will run jobs at regular intervals.
+
+```swift
+jobService.addScheduledJob(CleanupDatabaseJob(), schedule: .weekly(day: .sunday, hour: 4))
+// the scheduler also accepts crontab strings and will support most combinations
+jobService.addScheduledJob(CleanupDatabaseJob(), schedule: .crontab("0 4 * * sun"))
+```
 
 ## Documentation
 

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -48,8 +48,6 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == JobQueu
     func shutdownGracefully() async
     /// job queue context
     var context: JobQueueContext { get }
-    /// Schedule regular job queue cleanup
-    func scheduleQueueCleanup(_ schedule: inout JobSchedule)
 }
 
 extension JobQueueDriver {
@@ -57,8 +55,6 @@ extension JobQueueDriver {
     public func waitUntilReady() async throws {}
     /// default version of worker ID is to return the string version of a UUID
     public var context: JobQueueContext { .init(workerID: UUID().uuidString, metadata: [:]) }
-    /// Schedule regular job cleanup
-    public func scheduleQueueCleanup(_ schedule: inout JobSchedule) {}
 }
 
 extension JobQueueDriver {

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -48,6 +48,8 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == JobQueu
     func shutdownGracefully() async
     /// job queue context
     var context: JobQueueContext { get }
+    /// Schedule regular job queue cleanup
+    func scheduleQueueCleanup(_ schedule: inout JobSchedule)
 }
 
 extension JobQueueDriver {
@@ -55,6 +57,8 @@ extension JobQueueDriver {
     public func waitUntilReady() async throws {}
     /// default version of worker ID is to return the string version of a UUID
     public var context: JobQueueContext { .init(workerID: UUID().uuidString, metadata: [:]) }
+    /// Schedule regular job cleanup
+    public func scheduleQueueCleanup(_ schedule: inout JobSchedule) {}
 }
 
 extension JobQueueDriver {

--- a/Sources/Jobs/JobService.swift
+++ b/Sources/Jobs/JobService.swift
@@ -30,9 +30,10 @@ public struct JobService<Queue: JobQueueDriver>: JobQueueProtocol where Queue: J
         }
     }
 
+    /// Job queue that service uses
+    public let queue: JobQueue<Queue>
+
     let serviceOptions: Options
-    @usableFromInline
-    let queue: JobQueue<Queue>
     @usableFromInline
     var schedule: JobSchedule
 

--- a/Sources/Jobs/JobService.swift
+++ b/Sources/Jobs/JobService.swift
@@ -7,24 +7,26 @@
 //
 
 public import Logging
-import NIOCore
 public import ServiceLifecycle
 
 /// JobService brings together all the components of swift-jobs into one type
-public struct JobService<Queue: JobQueueDriver>: JobQueueProtocol where Queue: JobMetadataDriver {
+public struct JobService<Queue: JobQueueDriver>: JobQueueProtocol where Queue: JobServiceDriver {
     public struct Options: Sendable {
         var queue: JobQueueOptions
         var processor: JobQueueProcessorOptions
         var scheduler: JobSchedule.Scheduler<Queue>.Options
+        var cleanup: Queue.CleanupOptions
 
         public init(
             queue: JobQueueOptions = .init(),
             processor: JobQueueProcessorOptions = .init(),
-            scheduler: JobSchedule.Scheduler<Queue>.Options = .init()
+            scheduler: JobSchedule.Scheduler<Queue>.Options = .init(),
+            cleanup: Queue.CleanupOptions = .default
         ) {
             self.queue = queue
             self.processor = processor
             self.scheduler = scheduler
+            self.cleanup = cleanup
         }
     }
 
@@ -45,7 +47,7 @@ public struct JobService<Queue: JobQueueDriver>: JobQueueProtocol where Queue: J
         self.serviceOptions = options
         self.queue = .init(queue, logger: logger, options: options.queue, middleware: middleware)
         self.schedule = .init()
-        queue.scheduleQueueCleanup(&self.schedule)
+        queue.scheduleQueueCleanup(&self.schedule, options: options.cleanup)
     }
 
     public init(
@@ -57,7 +59,7 @@ public struct JobService<Queue: JobQueueDriver>: JobQueueProtocol where Queue: J
         self.serviceOptions = options
         self.queue = .init(queue, logger: logger, options: options.queue, middleware: middleware)
         self.schedule = .init()
-        queue.scheduleQueueCleanup(&self.schedule)
+        queue.scheduleQueueCleanup(&self.schedule, options: options.cleanup)
     }
 
     ///  Push Job onto queue

--- a/Sources/Jobs/JobService.swift
+++ b/Sources/Jobs/JobService.swift
@@ -45,6 +45,7 @@ public struct JobService<Queue: JobQueueDriver>: JobQueueProtocol where Queue: J
         self.serviceOptions = options
         self.queue = .init(queue, logger: logger, options: options.queue, middleware: middleware)
         self.schedule = .init()
+        queue.scheduleQueueCleanup(&self.schedule)
     }
 
     public init(
@@ -56,6 +57,7 @@ public struct JobService<Queue: JobQueueDriver>: JobQueueProtocol where Queue: J
         self.serviceOptions = options
         self.queue = .init(queue, logger: logger, options: options.queue, middleware: middleware)
         self.schedule = .init()
+        queue.scheduleQueueCleanup(&self.schedule)
     }
 
     ///  Push Job onto queue

--- a/Sources/Jobs/JobService.swift
+++ b/Sources/Jobs/JobService.swift
@@ -1,0 +1,130 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public import Logging
+import NIOCore
+public import ServiceLifecycle
+
+/// JobService brings together all the components of swift-jobs into one type
+public struct JobService<Queue: JobQueueDriver>: JobQueueProtocol where Queue: JobMetadataDriver {
+    public struct Options: Sendable {
+        var queue: JobQueueOptions
+        var processor: JobQueueProcessorOptions
+        var scheduler: JobSchedule.Scheduler<Queue>.Options
+
+        public init(
+            queue: JobQueueOptions = .init(),
+            processor: JobQueueProcessorOptions = .init(),
+            scheduler: JobSchedule.Scheduler<Queue>.Options = .init()
+        ) {
+            self.queue = queue
+            self.processor = processor
+            self.scheduler = scheduler
+        }
+    }
+
+    let serviceOptions: Options
+    @usableFromInline
+    let queue: JobQueue<Queue>
+    @usableFromInline
+    var schedule: JobSchedule
+
+    public var logger: Logger { queue.logger }
+
+    public init(
+        _ queue: Queue,
+        logger: Logger,
+        options: Options = .init(),
+        @JobMiddlewareBuilder middleware: () -> some JobMiddleware = { NullJobMiddleware() }
+    ) {
+        self.serviceOptions = options
+        self.queue = .init(queue, logger: logger, options: options.queue, middleware: middleware)
+        self.schedule = .init()
+    }
+
+    public init(
+        _ queue: Queue,
+        logger: Logger,
+        options: Options = .init(),
+        @JobMiddlewareBuilder middleware: (Queue) -> some JobMiddleware
+    ) {
+        self.serviceOptions = options
+        self.queue = .init(queue, logger: logger, options: options.queue, middleware: middleware)
+        self.schedule = .init()
+    }
+
+    ///  Push Job onto queue
+    /// - Parameters:
+    ///   - parameters: Job parameters
+    ///   - parameters: parameters for the job
+    /// - Returns: Identifier of queued job
+    @discardableResult
+    @inlinable
+    public func push<Parameters: Sendable>(
+        jobRequest: JobRequest<Parameters>,
+        options: Queue.JobOptions
+    ) async throws -> Queue.JobID {
+        try await self.queue.push(jobRequest: jobRequest, options: options)
+    }
+
+    ///  Register job type
+    /// - Parameters:
+    ///   - job: Job definition
+    @inlinable
+    public func registerJob(_ job: JobDefinition<some Sendable & Codable>) {
+        self.queue.registerJob(job)
+    }
+
+    ///  Create JobQueue processor that will process jobs pushed to the queue
+    /// - Parameter options: Processor options
+    @inlinable
+    public func processor(options: JobQueueProcessorOptions) -> any Service {
+        self.queue.processor(options: options)
+    }
+
+    /// Job queue options
+    @inlinable
+    public var options: JobQueueOptions { self.queue.options }
+
+    ///  Add Job to Schedule
+    /// - Parameters:
+    ///   - job: Job parameters
+    ///   - schedule: Schedule for job
+    @inlinable
+    public mutating func addScheduledJob(_ job: some JobParameters, schedule: Schedule, accuracy: JobSchedule.ScheduleAccuracy = .latest) {
+        self.schedule.addJob(job, schedule: schedule, accuracy: accuracy)
+    }
+
+    ///  Add Job to Schedule
+    /// - Parameters:
+    ///   - job: Job parameters
+    ///   - schedule: Schedule for job
+    @inlinable
+    public mutating func addScheduledJob<Parameters: Sendable & Codable>(
+        _ jobName: JobName<Parameters>,
+        parameters: Parameters,
+        schedule: Schedule,
+        accuracy: JobSchedule.ScheduleAccuracy = .latest
+    ) {
+        self.schedule.addJob(jobName, parameters: parameters, schedule: schedule, accuracy: accuracy)
+    }
+}
+
+extension JobService: Service {
+    public func run() async throws {
+        let serviceGroup = await ServiceGroup(
+            services: [
+                self.queue.processor(options: self.serviceOptions.processor),
+                self.schedule.scheduler(on: queue, named: self.queue.queue.context.queueName, options: self.serviceOptions.scheduler),
+            ],
+            gracefulShutdownSignals: [],
+            logger: self.logger
+        )
+        try await serviceGroup.run()
+    }
+}

--- a/Sources/Jobs/JobServiceDriver.swift
+++ b/Sources/Jobs/JobServiceDriver.swift
@@ -1,0 +1,20 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// Protocol for JobQueue clean up Options
+public protocol JobQueueCleanupOptionsProtocol: Sendable {
+    static var `default`: Self { get }
+}
+
+/// A queue that can be used with the JobService type
+public protocol JobServiceDriver: JobQueueDriver, JobMetadataDriver {
+    associatedtype CleanupOptions: JobQueueCleanupOptionsProtocol
+
+    /// Schedule regular job queue cleanup
+    func scheduleQueueCleanup(_ schedule: inout JobSchedule, options: CleanupOptions)
+}

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -16,7 +16,7 @@ public import Foundation
 #endif
 
 /// In memory implementation of job queue driver. Stores job data in a circular buffer
-public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJobQueue {
+public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJobQueue, JobServiceDriver {
     public typealias Element = JobQueueResult<JobID>
     public typealias JobID = UUID
     /// Job options
@@ -33,6 +33,9 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
         public init(delayUntil: Date = .now) {
             self.delayUntil = delayUntil
         }
+    }
+    public struct CleanupOptions: JobQueueCleanupOptionsProtocol {
+        public static var `default`: Self { .init() }
     }
 
     /// queue of jobs
@@ -112,6 +115,8 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
     public func pause(jobID: JobID) async throws {
         await self.queue.pauseJob(jobID: jobID)
     }
+
+    public func scheduleQueueCleanup(_ schedule: inout JobSchedule, options: CleanupOptions) {}
 
     /// Internal actor managing the job queue
     fileprivate actor Internal {

--- a/Tests/JobsTests/JobServiceTests.swift
+++ b/Tests/JobsTests/JobServiceTests.swift
@@ -1,0 +1,57 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import Jobs
+import Logging
+import ServiceLifecycle
+import Synchronization
+import Testing
+
+struct JobServiceTests {
+    @Test func runJob() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "runJob"
+            let value: Int
+        }
+        var logger = Logger(label: "runJob")
+        logger.logLevel = .trace
+        let jobService = JobService(.memory, logger: logger)
+        async let _ = jobService.run()
+
+        let (stream, cont) = AsyncStream.makeStream(of: Int.self)
+        jobService.registerJob(parameters: TestParameters.self) { parameter, _ in
+            cont.yield(parameter.value)
+        }
+        try await jobService.push(TestParameters(value: 4))
+        let value = await stream.first { _ in true }
+        #expect(value == 4)
+    }
+
+    @Test func runScheduledJob() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "runScheduledJob"
+            let value: Int
+        }
+        var logger = Logger(label: "runScheduledJob")
+        logger.logLevel = .trace
+        var jobService = JobService(.memory, logger: logger)
+
+        let (stream, cont) = AsyncStream.makeStream(of: Int.self)
+        jobService.registerJob(parameters: TestParameters.self) { parameter, _ in
+            cont.yield(parameter.value)
+        }
+        // create schedule that ensures a job will be run in the next second
+        let dateComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: Date.now + 1)
+        jobService.addScheduledJob(TestParameters(value: 8), schedule: .everyMinute(second: dateComponents.second!))
+
+        async let _ = jobService.run()
+        let value = await stream.first { _ in true }
+        #expect(value == 8)
+    }
+}


### PR DESCRIPTION
- Added JobService type to wrap a job queue and a job schedule. It will also manage the running of both scheduler and queue processor. 
- Added `JobQueueDriver.scheduleQueueCleanup` which is called from the `JobService` to setup scheduled cleanup jobs. Added default that does nothing, but will add implementation in valkey and postgres that add regular cleanup jobs

```swift
let jobService = JobService(.memory, options: .init(processor: .init(numWorkers: 32)), logger: logger)
jobService.registerJob(parameters: TestParameters.self) { parameter, _ in
    ...
}
jobService.addScheduledJob(TestParameters(value: 56), schedule: .hourly())
async let _ = jobService.run()
```
