### PR TITLE
API for accessing status of jobs driver

### DIFF
--- a/Sources/Jobs/API/JobsAPI.swift
+++ b/Sources/Jobs/API/JobsAPI.swift
@@ -1,0 +1,56 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+public import NIOCore
+
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
+public import Foundation
+#endif
+
+@_spi(JobsAPI) public struct JobAPIMetadata: Sendable {
+    @nonexhaustive
+    public enum Status: String, Sendable {
+        case pending
+        case processing
+        case completed
+        case failed
+        case cancelled
+        case paused
+    }
+    public let id: UUID
+    public let name: String
+    public let createdAt: Date
+    public let completedAt: Date?
+    public let status: Status
+}
+
+@_spi(JobsAPI) public struct GetJobsResponse: Sendable {
+    public let paginationToken: String?
+    public let jobs: [JobAPIMetadata]
+}
+
+@_spi(JobsAPI) public struct GetJobResponse: Sendable {
+    public let jobMetadata: JobAPIMetadata
+    public let jobParameters: ByteBuffer
+}
+
+@_spi(JobsAPI) public protocol JobsAPI {
+    /// Get list of job descriptions from job queue
+    /// - Parameters:
+    ///   - maxNumber: Maximum number of jobs to return
+    ///   - paginationToken: Optional pagination token
+    /// - Returns: Array of job descriptions and pagination token
+    func getJobs(maxNumber: Int, paginationToken: String?) async throws -> GetJobsResponse
+    /// Get job parameters
+    /// - Parameters:
+    ///   - id: Job ID
+    /// - Returns: Job parameters
+    func getJob(id: UUID) async throws -> GetJobResponse?
+}

--- a/Sources/Jobs/API/JobsAPI.swift
+++ b/Sources/Jobs/API/JobsAPI.swift
@@ -31,16 +31,34 @@ public import Foundation
     public let createdAt: Date
     public let completedAt: Date?
     public let status: Status
+
+    public init(id: UUID, name: String, createdAt: Date, completedAt: Date? = nil, status: JobAPIMetadata.Status) {
+        self.id = id
+        self.name = name
+        self.createdAt = createdAt
+        self.completedAt = completedAt
+        self.status = status
+    }
 }
 
 @_spi(JobsAPI) public struct GetJobsResponse: Sendable {
     public let paginationToken: String?
     public let jobs: [JobAPIMetadata]
+
+    public init(paginationToken: String? = nil, jobs: [JobAPIMetadata]) {
+        self.paginationToken = paginationToken
+        self.jobs = jobs
+    }
 }
 
 @_spi(JobsAPI) public struct GetJobResponse: Sendable {
     public let jobMetadata: JobAPIMetadata
     public let jobParameters: ByteBuffer
+
+    public init(jobMetadata: JobAPIMetadata, jobParameters: ByteBuffer) {
+        self.jobMetadata = jobMetadata
+        self.jobParameters = jobParameters
+    }
 }
 
 @_spi(JobsAPI) public protocol JobsAPI {

--- a/Sources/Jobs/API/JobsAPI.swift
+++ b/Sources/Jobs/API/JobsAPI.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if compiler(>=6.2.3)
+
 public import NIOCore
 
 #if canImport(FoundationEssentials)
@@ -54,3 +56,5 @@ public import Foundation
     /// - Returns: Job parameters
     func getJob(id: UUID) async throws -> GetJobResponse?
 }
+
+#endif

--- a/Sources/Jobs/API/MemoryJobQueue+api.swift
+++ b/Sources/Jobs/API/MemoryJobQueue+api.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if compiler(>=6.2.3)
+
 import DequeModule
 import NIOCore
 
@@ -103,3 +105,5 @@ extension MemoryQueue.Internal {
         return nil
     }
 }
+
+#endif

--- a/Sources/Jobs/API/MemoryJobQueue+api.swift
+++ b/Sources/Jobs/API/MemoryJobQueue+api.swift
@@ -1,0 +1,105 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import DequeModule
+import NIOCore
+
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
+public import Foundation
+#endif
+
+@_spi(JobsAPI) extension MemoryQueue: JobsAPI {
+    public func getJobs(maxNumber: Int, paginationToken: String?) async throws -> GetJobsResponse {
+        let index = paginationToken.flatMap { Int($0) } ?? 0
+        let jobs = await self.queue.getJobs(maxNumber: maxNumber, index: index)
+        return try .init(
+            paginationToken: jobs.count != maxNumber ? nil : "\(index + maxNumber)",
+            jobs: jobs.map {
+                let jobInstance = try self.jobRegistry.decode($0.buffer)
+                return JobAPIMetadata(id: $0.id, name: jobInstance.name, createdAt: jobInstance.queuedAt, completedAt: nil, status: $0.status)
+            }
+        )
+    }
+
+    public func getJob(id: UUID) async throws -> GetJobResponse? {
+        guard let job = await self.queue.getJob(id: id) else { return nil }
+        let jobInstance = try self.jobRegistry.decode(job.buffer)
+        return GetJobResponse(
+            jobMetadata: .init(id: id, name: jobInstance.name, createdAt: jobInstance.queuedAt, completedAt: nil, status: job.status),
+            jobParameters: job.buffer
+        )
+    }
+}
+
+extension MemoryQueue.Internal {
+    func getJobs(maxNumber: Int, index: Int) async -> [(id: UUID, status: JobAPIMetadata.Status, buffer: ByteBuffer)] {
+        var maxNumber = maxNumber
+        var index = index
+        var jobs: [(id: UUID, status: JobAPIMetadata.Status, buffer: ByteBuffer)] = []
+
+        jobs.append(
+            contentsOf: getJobs(from: self.queue.lazy.reversed().map { $0.job }, index: &index, max: &maxNumber).map {
+                (id: $0.id, status: .pending, buffer: $0.jobBuffer)
+            }
+        )
+        jobs.append(
+            contentsOf: getJobs(
+                from: self.processingJobs.lazy.reversed().map { .init(id: $0.key, jobBuffer: $0.value) },
+                index: &index,
+                max: &maxNumber
+            ).map {
+                (id: $0.id, status: .processing, buffer: $0.jobBuffer)
+            }
+        )
+        jobs.append(
+            contentsOf: getJobs(from: self.pausedJobs.lazy.reversed().map { .init(id: $0.key, jobBuffer: $0.value) }, index: &index, max: &maxNumber)
+                .map {
+                    (id: $0.id, status: .paused, buffer: $0.jobBuffer)
+                }
+        )
+        jobs.append(
+            contentsOf: getJobs(from: self.failedJobs.lazy.reversed().map { .init(id: $0.key, jobBuffer: $0.value) }, index: &index, max: &maxNumber)
+                .map {
+                    (id: $0.id, status: .failed, buffer: $0.jobBuffer)
+                }
+        )
+        return jobs
+    }
+
+    func getJobs(from collection: some Collection<QueuedJob>, index: inout Int, max: inout Int) -> [QueuedJob] {
+        if max == 0 {
+            return []
+        } else if index < collection.count {
+            let count = min(max, collection.count - index)
+            let startIndex = collection.index(collection.startIndex, offsetBy: index)
+            let endIndex = collection.index(startIndex, offsetBy: count)
+            let jobs = collection[startIndex..<endIndex].map { $0 }
+            index = 0
+            max -= count
+            return jobs
+        } else {
+            index -= collection.count
+            return []
+        }
+    }
+
+    func getJob(id: UUID) async -> (status: JobAPIMetadata.Status, buffer: ByteBuffer)? {
+        if let job = self.queue.first(where: { $0.job.id == id }) {
+            return (.pending, job.job.jobBuffer)
+        } else if let jobBuffer = self.processingJobs[id] {
+            return (.processing, jobBuffer)
+        } else if let jobBuffer = self.failedJobs[id] {
+            return (.failed, jobBuffer)
+        } else if let jobBuffer = self.pausedJobs[id] {
+            return (.paused, jobBuffer)
+        }
+        return nil
+    }
+}

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -39,9 +39,9 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
     }
 
     /// queue of jobs
-    fileprivate let queue: Internal
+    internal let queue: Internal
     private let onFailedJob: @Sendable (JobID, any Error) -> Void
-    private let jobRegistry: JobRegistry
+    internal let jobRegistry: JobRegistry
     public let context: JobQueueContext
 
     /// Initialise In memory job queue
@@ -119,7 +119,7 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
     public func scheduleQueueCleanup(_ schedule: inout JobSchedule, options: CleanupOptions) {}
 
     /// Internal actor managing the job queue
-    fileprivate actor Internal {
+    internal actor Internal {
         struct QueuedJob: Sendable {
             let id: JobID
             let jobBuffer: ByteBuffer

--- a/Tests/JobsTests/JobsAPITests.swift
+++ b/Tests/JobsTests/JobsAPITests.swift
@@ -1,0 +1,243 @@
+//
+// This source file is part of the Hummingbird server framework project
+// Copyright (c) the Hummingbird authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+@_spi(JobsAPI) import Jobs
+import Logging
+import Testing
+
+struct JobsAPITests {
+    @Test func testPendingProcessingStatus() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "testPendingProcessingStatus"
+            let value: Int
+        }
+        let logger = Logger(label: "JobsTests")
+        let jobQueue = JobQueue(.memory, logger: logger)
+        let (jobStartStream, jobStartCont) = AsyncStream.makeStream(of: Void.self)
+        let (jobDoneStream, jobDoneCont) = AsyncStream.makeStream(of: Void.self)
+        let job = JobDefinition { (parameters: TestParameters, context) in
+            context.logger.info("Parameters=\(parameters.value)")
+            jobStartCont.yield()
+            await jobDoneStream.first { _ in true }
+        }
+        jobQueue.registerJob(job)
+        let id = try await jobQueue.push(TestParameters(value: 1))
+        let id2 = try await jobQueue.push(TestParameters(value: 1))
+
+        // we've pushed two jobs. We should have two pending jobs
+        let jobs = try await jobQueue.queue.getJobs(maxNumber: .max, paginationToken: nil)
+        #expect(jobs.jobs.count == 2)
+        #expect(jobs.jobs[0].status == .pending)
+        #expect(jobs.jobs[0].name == "testPendingProcessingStatus")
+        #expect(jobs.jobs[0].id == id2)
+        #expect(jobs.jobs[1].status == .pending)
+        #expect(jobs.jobs[1].name == "testPendingProcessingStatus")
+        #expect(jobs.jobs[1].id == id)
+
+        try await testJobQueue(JobQueueProcessor(queue: jobQueue, logger: logger, options: .init(numWorkers: 1))) {
+            await jobStartStream.first { _ in true }
+
+            // Now the queue is being processed and we have waiting for one job to start we should have one
+            // job pending and one job processing
+            let jobs = try await jobQueue.queue.getJobs(maxNumber: .max, paginationToken: nil)
+            #expect(jobs.jobs.count == 2)
+            #expect(jobs.jobs[0].status == .pending)
+            #expect(jobs.jobs[0].name == "testPendingProcessingStatus")
+            #expect(jobs.jobs[0].id == id2)
+            #expect(jobs.jobs[1].status == .processing)
+            #expect(jobs.jobs[1].name == "testPendingProcessingStatus")
+            #expect(jobs.jobs[1].id == id)
+
+            jobDoneCont.yield()
+
+            await jobStartStream.first { _ in true }
+
+            // We wait for another job to start the first job is no longer available as the memory queue doesn't
+            // store completed jobs, but the second job is processing
+            let jobs2 = try await jobQueue.queue.getJobs(maxNumber: .max, paginationToken: nil)
+            #expect(jobs2.jobs.count == 1)
+            #expect(jobs2.jobs[0].id == id2)
+            #expect(jobs2.jobs[0].status == .processing)
+
+            jobDoneCont.yield()
+        }
+    }
+
+    @Test func testPausedStatus() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "testPausedStatus"
+            let value: Int
+        }
+        let logger = Logger(label: "JobsTests")
+        let jobQueue = JobQueue(.memory, logger: logger)
+        let job = JobDefinition { (parameters: TestParameters, context) in
+            context.logger.info("Parameters=\(parameters.value)")
+        }
+        jobQueue.registerJob(job)
+        let id = try await jobQueue.push(TestParameters(value: 1))
+        try await jobQueue.pauseJob(jobID: id)
+
+        // we've pushed two jobs. We should have two pending jobs
+        let jobs = try await jobQueue.queue.getJobs(maxNumber: .max, paginationToken: nil)
+        #expect(jobs.jobs.count == 1)
+        #expect(jobs.jobs[0].status == .paused)
+        #expect(jobs.jobs[0].name == "testPausedStatus")
+        #expect(jobs.jobs[0].id == id)
+    }
+
+    @Test func testFailedStatus() async throws {
+        struct TestError: Error {}
+        struct TestParameters: JobParameters {
+            static let jobName = "testFailedStatus"
+            let fail: Bool
+        }
+        let logger = Logger(label: "JobsTests")
+        let jobQueue = JobQueue(.memory, logger: logger)
+        let (jobStartStream, jobStartCont) = AsyncStream.makeStream(of: Void.self)
+        let (jobDoneStream, jobDoneCont) = AsyncStream.makeStream(of: Void.self)
+        let job = JobDefinition { (parameters: TestParameters, context) in
+            jobStartCont.yield()
+            if parameters.fail {
+                await jobDoneStream.first { _ in true }
+                throw TestError()
+            }
+            await jobDoneStream.first { _ in true }
+        }
+        jobQueue.registerJob(job)
+        let id = try await jobQueue.push(TestParameters(fail: true))
+        let id2 = try await jobQueue.push(TestParameters(fail: false))
+
+        // we've pushed two jobs. We should have two pending jobs
+        let jobs = try await jobQueue.queue.getJobs(maxNumber: .max, paginationToken: nil)
+        #expect(jobs.jobs.count == 2)
+        #expect(jobs.jobs[0].status == .pending)
+        #expect(jobs.jobs[0].name == "testFailedStatus")
+        #expect(jobs.jobs[0].id == id2)
+        #expect(jobs.jobs[1].status == .pending)
+        #expect(jobs.jobs[1].name == "testFailedStatus")
+        #expect(jobs.jobs[1].id == id)
+
+        try await testJobQueue(JobQueueProcessor(queue: jobQueue, logger: logger, options: .init(numWorkers: 1))) {
+            // trigger job, have it finish and trigger next job
+            await jobStartStream.first { _ in true }
+            jobDoneCont.yield()
+            await jobStartStream.first { _ in true }
+
+            // We wait for another job to start the first job is no longer available as the memory queue doesn't
+            // store completed jobs, but the second job is processing
+            let jobs2 = try await jobQueue.queue.getJobs(maxNumber: .max, paginationToken: nil)
+            #expect(jobs2.jobs.count == 2)
+            #expect(jobs2.jobs[1].id == id)
+            #expect(jobs2.jobs[1].status == .failed)
+
+            jobDoneCont.yield()
+        }
+    }
+
+    @Test func testPendingPagination() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "testPendingPagination"
+            let value: Int
+        }
+        let logger = Logger(label: "JobsTests")
+        let jobQueue = JobQueue(.memory, logger: logger)
+        let job = JobDefinition { (parameters: TestParameters, context) in
+            context.logger.info("Parameters=\(parameters.value)")
+        }
+        jobQueue.registerJob(job)
+        var ids: [MemoryQueue.JobID] = []
+        for i in 0..<10 {
+            try await ids.append(jobQueue.push(TestParameters(value: i)))
+        }
+
+        // we've pushed ten jobs. We should have ten pending jobs across two call to getJobs
+        var response = try await jobQueue.queue.getJobs(maxNumber: 6, paginationToken: nil)
+        #expect(response.jobs.count == 6)
+        for job in response.jobs {
+            #expect(job.status == .pending)
+            #expect(job.name == "testPendingPagination")
+        }
+        response = try await jobQueue.queue.getJobs(maxNumber: 6, paginationToken: response.paginationToken)
+        #expect(response.jobs.count == 4)
+        for job in response.jobs {
+            #expect(job.status == .pending)
+            #expect(job.name == "testPendingPagination")
+        }
+    }
+
+    @Test func testPagination() async throws {
+        struct TestError: Error {}
+        struct TestParameters: JobParameters {
+            static let jobName = "testPagination"
+            let value: Int
+        }
+        let logger = Logger(label: "JobsTests")
+        let jobQueue = JobQueue(.memory, logger: logger)
+        let (jobStartStream, jobStartCont) = AsyncStream.makeStream(of: Void.self)
+        let (jobDoneStream, jobDoneCont) = AsyncStream.makeStream(of: Void.self)
+        let job = JobDefinition { (parameters: TestParameters, context) in
+            context.logger.info("Parameters=\(parameters.value)")
+            jobStartCont.yield()
+            await jobDoneStream.first { _ in true }
+            throw TestError()
+        }
+        jobQueue.registerJob(job)
+        var ids: [MemoryQueue.JobID] = []
+        for i in 0..<10 {
+            try await ids.append(jobQueue.push(TestParameters(value: i)))
+        }
+
+        try await testJobQueue(JobQueueProcessor(queue: jobQueue, logger: logger, options: .init(numWorkers: 1))) {
+            await jobStartStream.first { _ in true }
+            jobDoneCont.yield()
+
+            await jobStartStream.first { _ in true }
+
+            // we've pushed ten jobs. One has failed and one is in progress. We should have ten pending jobs across
+            // two call to getJobs. And the last job should be failed and the second last processing
+            var response = try await jobQueue.queue.getJobs(maxNumber: 6, paginationToken: nil)
+            #expect(response.jobs.count == 6)
+            for job in response.jobs {
+                #expect(job.status == .pending)
+                #expect(job.name == "testPagination")
+            }
+            response = try await jobQueue.queue.getJobs(maxNumber: 6, paginationToken: response.paginationToken)
+            #expect(response.jobs.count == 4)
+            for job in response.jobs.dropLast(2) {
+                #expect(job.status == .pending)
+                #expect(job.name == "testPagination")
+            }
+            #expect(response.jobs[2].status == .processing)
+            #expect(response.jobs[3].status == .failed)
+            jobDoneCont.yield()
+            for _ in 0..<8 {
+                jobDoneCont.yield()
+            }
+        }
+    }
+
+    @Test func testCreatedAt() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "testCreatedAt"
+            let value: Int
+        }
+        let logger = Logger(label: "JobsTests")
+        let jobQueue = JobQueue(.memory, logger: logger)
+        let job = JobDefinition { (parameters: TestParameters, context) in
+            context.logger.info("Parameters=\(parameters.value)")
+        }
+        jobQueue.registerJob(job)
+        let id = try await jobQueue.push(TestParameters(value: 1))
+
+        // we've pushed two jobs. We should have two pending jobs
+        let jobs = try await jobQueue.queue.getJobs(maxNumber: .max, paginationToken: nil)
+        #expect(jobs.jobs.count == 1)
+        #expect(jobs.jobs[0].status == .pending)
+        #expect(abs(jobs.jobs[0].createdAt.timeIntervalSinceNow) < 10)
+        #expect(jobs.jobs[0].id == id)
+    }
+}

--- a/Tests/JobsTests/JobsAPITests.swift
+++ b/Tests/JobsTests/JobsAPITests.swift
@@ -5,6 +5,9 @@
 // See LICENSE.txt for license information
 // SPDX-License-Identifier: Apache-2.0
 //
+
+#if compiler(>=6.2.3)
+
 @_spi(JobsAPI) import Jobs
 import Logging
 import Testing
@@ -241,3 +244,5 @@ struct JobsAPITests {
         #expect(jobs.jobs[0].id == id)
     }
 }
+
+#endif


### PR DESCRIPTION
Moved into main repository.

It wasn't possible to actually implement the protocol for any of the drivers outside of their own modules. So I've decided to move this to swift-jobs and hide it behind an SPI private API.

This PR includes an implementation for the memory queue and some tests.