### PR TITLE
Add per job definition option to not retain completed or failed jobs

### DIFF
--- a/Sources/Jobs/JobDefinition.swift
+++ b/Sources/Jobs/JobDefinition.swift
@@ -14,7 +14,7 @@ public struct JobDefinitionOptions: OptionSet, Sendable {
     }
     /// When job has completed or failed we should not record its state even if the
     /// job queue driver has indicated it will store the state.
-    static var doNotRetain: Self { self.init(rawValue: 1 << 0) }
+    public static var doNotRetain: Self { self.init(rawValue: 1 << 0) }
 }
 
 /// Job definition type

--- a/Sources/Jobs/JobDefinition.swift
+++ b/Sources/Jobs/JobDefinition.swift
@@ -12,9 +12,12 @@ public struct JobDefinitionOptions: OptionSet, Sendable {
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
-    /// When job has completed or failed we should not record its state even if the
-    /// job queue driver has indicated it will store the state.
-    public static var doNotRetain: Self { self.init(rawValue: 1 << 0) }
+    /// When job has completed we should not retain record of this job regardless of
+    /// whether job queue driver has indicated it will store the state.
+    public static var doNotRetainCompleted: Self { self.init(rawValue: 1 << 0) }
+    /// When job has failed we should not retain record of this job regardless of
+    /// whether job queue driver has indicated it will store the state.
+    public static var doNotRetainFailed: Self { self.init(rawValue: 1 << 1) }
 }
 
 /// Job definition type

--- a/Sources/Jobs/JobDefinition.swift
+++ b/Sources/Jobs/JobDefinition.swift
@@ -6,11 +6,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+public struct JobDefinitionOptions: OptionSet, Sendable {
+    public var rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    /// When job has completed or failed we should not record its state even if the
+    /// job queue driver has indicated it will store the state.
+    static var doNotRetain: Self { self.init(rawValue: 1 << 0) }
+}
+
 /// Job definition type
 public struct JobDefinition<Parameters: Codable & Sendable>: Sendable {
     let name: String
-    let retryStrategy: any JobRetryStrategy
-    let timeout: Duration?
+    var retryStrategy: any JobRetryStrategy
+    var timeout: Duration?
+    var options: JobDefinitionOptions
     let _execute: @Sendable (Parameters, JobExecutionContext) async throws -> Void
 
     ///  Initialize JobDefinition
@@ -29,6 +41,7 @@ public struct JobDefinition<Parameters: Codable & Sendable>: Sendable {
         self.retryStrategy = retryStrategy
         self._execute = execute
         self.timeout = timeout
+        self.options = []
     }
 
     ///  Initialize JobDefinition
@@ -49,6 +62,7 @@ public struct JobDefinition<Parameters: Codable & Sendable>: Sendable {
         self.retryStrategy = retryStrategy
         self._execute = execute
         self.timeout = timeout
+        self.options = []
     }
 
     ///  Initialize JobDefinition
@@ -66,6 +80,7 @@ public struct JobDefinition<Parameters: Codable & Sendable>: Sendable {
         self.retryStrategy = ExponentialJitterJobRetryStrategy(maxAttempts: maxRetryCount)
         self._execute = execute
         self.timeout = nil
+        self.options = []
     }
 
     func execute(_ parameters: Parameters, context: JobExecutionContext) async throws {

--- a/Sources/Jobs/JobDefinition.swift
+++ b/Sources/Jobs/JobDefinition.swift
@@ -20,9 +20,9 @@ public struct JobDefinitionOptions: OptionSet, Sendable {
 /// Job definition type
 public struct JobDefinition<Parameters: Codable & Sendable>: Sendable {
     let name: String
-    var retryStrategy: any JobRetryStrategy
-    var timeout: Duration?
-    var options: JobDefinitionOptions
+    public var retryStrategy: any JobRetryStrategy
+    public var timeout: Duration?
+    public var options: JobDefinitionOptions
     let _execute: @Sendable (Parameters, JobExecutionContext) async throws -> Void
 
     ///  Initialize JobDefinition

--- a/Sources/Jobs/JobInstance.swift
+++ b/Sources/Jobs/JobInstance.swift
@@ -34,6 +34,8 @@ public protocol JobInstanceProtocol: Sendable {
     var nextScheduledAt: Date? { get }
     /// Timeout
     var timeout: Duration? { get }
+    /// Job Options
+    var options: JobDefinitionOptions { get }
     /// Function to execute the job
     func execute(context: JobExecutionContext) async throws
 }
@@ -53,6 +55,9 @@ extension JobInstanceProtocol {
         }
         return nil
     }
+
+    /// default job options
+    public var options: JobDefinitionOptions { [] }
 }
 
 extension JobInstanceProtocol where Parameters: JobParameters {
@@ -84,6 +89,8 @@ struct JobInstance<Parameters: Sendable & Codable>: JobInstanceProtocol {
     var nextScheduledAt: Date? { self.data.nextScheduledAt }
     /// Timeout for long running jobs
     var timeout: Duration? { self.job.timeout }
+    /// Job Options
+    var options: JobDefinitionOptions { self.job.options }
 
     func execute(context: JobExecutionContext) async throws {
         try await self.job.execute(self.data.parameters, context: context)

--- a/Sources/Jobs/JobQueueDriver.swift
+++ b/Sources/Jobs/JobQueueDriver.swift
@@ -42,6 +42,10 @@ public protocol JobQueueDriver: AsyncSequence, Sendable where Element == JobQueu
     func finished(jobID: JobID) async throws
     /// This is called to say job has failed to run and should be put aside
     func failed(jobID: JobID, error: any Error) async throws
+    /// This is called to say job has finished processing and it can be deleted
+    func finished(jobID: JobID, retain: Bool) async throws
+    /// This is called to say job has failed to run and should be put aside
+    func failed(jobID: JobID, error: any Error, retain: Bool) async throws
     /// stop serving jobs
     func stop() async
     /// shutdown queue
@@ -61,6 +65,15 @@ extension JobQueueDriver {
     func retry(_ jobID: JobID, job: some JobInstanceProtocol, attempt: Int, options: JobRetryOptions) async throws {
         let jobRequest = JobRequest(name: job.name, parameters: job.parameters, queuedAt: job.queuedAt, attempt: attempt)
         return try await self.retry(jobID, jobRequest: jobRequest, options: options)
+    }
+
+    /// This is called to say job has finished processing and it can be deleted
+    public func finished(jobID: JobID, retain: Bool) async throws {
+        try await self.finished(jobID: jobID)
+    }
+    /// This is called to say job has failed to run and should be put aside
+    public func failed(jobID: JobID, error: any Error, retain: Bool) async throws {
+        try await self.failed(jobID: jobID, error: error)
     }
 }
 

--- a/Sources/Jobs/JobQueueProcessor.swift
+++ b/Sources/Jobs/JobQueueProcessor.swift
@@ -179,7 +179,7 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
                 // as soon as we create it so can guarantee the Task is done when we leave the
                 // function.
                 try await Task {
-                    try await self.queue.failed(jobID: jobID, error: error)
+                    try await self.queue.failed(jobID: jobID, error: error, retain: !job.options.contains(.doNotRetain))
                 }.value
                 await self.middleware.onCompletedJob(job: job, result: .failure(error), context: .init(jobID: jobID.description))
                 return
@@ -211,7 +211,7 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
             } catch {
                 if !job.shouldRetry(error: error) {
                     logger.debug("Job: failed")
-                    try await self.queue.failed(jobID: jobID, error: error)
+                    try await self.queue.failed(jobID: jobID, error: error, retain: !job.options.contains(.doNotRetain))
                     await self.middleware.onCompletedJob(job: job, result: .failure(error), context: .init(jobID: jobID.description))
                     return
                 }
@@ -245,7 +245,7 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
                 return
             }
             logger.debug("Finished Job")
-            try await self.queue.finished(jobID: jobID)
+            try await self.queue.finished(jobID: jobID, retain: !job.options.contains(.doNotRetain))
             await self.middleware.onCompletedJob(job: job, result: .success(()), context: .init(jobID: jobID.description))
         } catch {
             logger.debug("Failed to set job status")

--- a/Sources/Jobs/JobQueueProcessor.swift
+++ b/Sources/Jobs/JobQueueProcessor.swift
@@ -179,7 +179,7 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
                 // as soon as we create it so can guarantee the Task is done when we leave the
                 // function.
                 try await Task {
-                    try await self.queue.failed(jobID: jobID, error: error, retain: !job.options.contains(.doNotRetain))
+                    try await self.queue.failed(jobID: jobID, error: error, retain: !job.options.contains(.doNotRetainFailed))
                 }.value
                 await self.middleware.onCompletedJob(job: job, result: .failure(error), context: .init(jobID: jobID.description))
                 return
@@ -211,7 +211,7 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
             } catch {
                 if !job.shouldRetry(error: error) {
                     logger.debug("Job: failed")
-                    try await self.queue.failed(jobID: jobID, error: error, retain: !job.options.contains(.doNotRetain))
+                    try await self.queue.failed(jobID: jobID, error: error, retain: !job.options.contains(.doNotRetainFailed))
                     await self.middleware.onCompletedJob(job: job, result: .failure(error), context: .init(jobID: jobID.description))
                     return
                 }
@@ -245,7 +245,7 @@ public final class JobQueueProcessor<Queue: JobQueueDriver>: Service {
                 return
             }
             logger.debug("Finished Job")
-            try await self.queue.finished(jobID: jobID, retain: !job.options.contains(.doNotRetain))
+            try await self.queue.finished(jobID: jobID, retain: !job.options.contains(.doNotRetainCompleted))
             await self.middleware.onCompletedJob(job: job, result: .success(()), context: .init(jobID: jobID.description))
         } catch {
             logger.debug("Failed to set job status")

--- a/Sources/Jobs/MemoryJobQueue.swift
+++ b/Sources/Jobs/MemoryJobQueue.swift
@@ -98,12 +98,24 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
         await self.queue.clearProcessingJob(jobID: jobID)
     }
 
-    public func failed(jobID: JobID, error: any Error) async throws {
-        if await self.queue.failJob(jobID: jobID) {
+    public func failed(jobID: JobID, error: any Error, retain: Bool) async throws {
+        if await self.queue.failJob(jobID: jobID, retain: retain) {
             self.onFailedJob(jobID, error)
         }
     }
 
+    @available(*, deprecated, message: "Failed without a retain is no longer used")
+    public func failed(jobID: JobID, error: any Error) async throws {
+        if await self.queue.failJob(jobID: jobID, retain: false) {
+            self.onFailedJob(jobID, error)
+        }
+    }
+
+    public func cancel(jobID: JobID, retain: Bool) async throws {
+        await self.queue.cancelJob(jobID: jobID)
+    }
+
+    @available(*, deprecated, message: "Failed without a retain is no longer used")
     public func cancel(jobID: JobID) async throws {
         await self.queue.cancelJob(jobID: jobID)
     }
@@ -117,6 +129,12 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
     }
 
     public func scheduleQueueCleanup(_ schedule: inout JobSchedule, options: CleanupOptions) {}
+
+    var failedJobs: [JobID: ByteBuffer] {
+        get async {
+            await self.queue.failedJobs
+        }
+    }
 
     /// Internal actor managing the job queue
     fileprivate actor Internal {
@@ -174,11 +192,13 @@ public final class MemoryQueue: JobQueueDriver, CancellableJobQueue, ResumableJo
             }
         }
 
-        func failJob(jobID: JobID) -> Bool {
+        func failJob(jobID: JobID, retain: Bool) -> Bool {
             let instance = self.processingJobs[jobID]
             self.clearProcessingJob(jobID: jobID)
             self.processingJobs[jobID] = nil
-            self.failedJobs[jobID] = instance
+            if retain {
+                self.failedJobs[jobID] = instance
+            }
             return instance != nil
         }
 

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -200,6 +200,39 @@ struct JobsTests {
         #expect(attemptCounter.withLock { $0 } == [1, 2, 3])
     }
 
+    @Test func testDoNotRetainOption() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "testErrorRetryCount"
+        }
+        let (stream, cont) = AsyncStream.makeStream(of: Void.self)
+        struct FailedError: Error {}
+        var logger = Logger(label: "JobsTests")
+        logger.logLevel = .trace
+        let memoryQueue = MemoryQueue()
+        let jobQueue = JobQueue(
+            memoryQueue,
+            logger: logger
+        )
+        var jobDefintion = JobDefinition(
+            parameters: TestParameters.self
+        ) { _, context in
+            cont.yield()
+            throw FailedError()
+        }
+        jobDefintion.options = [.doNotRetain]
+        jobQueue.registerJob(jobDefintion)
+
+        try await testJobQueue(jobQueue.processor(options: .init(numWorkers: 1))) {
+            try await jobQueue.push(TestParameters())
+            try await jobQueue.push(TestParameters())
+
+            var iterator = stream.makeAsyncIterator()
+            _ = await iterator.next()
+            _ = await iterator.next()
+        }
+        #expect(await memoryQueue.failedJobs.isEmpty)
+    }
+
     /// Test retry policy that does different things based on the error passed to it
     @Test func testRetryHandlerErrorChecking() async throws {
         struct TestError: Error {}

--- a/Tests/JobsTests/JobsTests.swift
+++ b/Tests/JobsTests/JobsTests.swift
@@ -219,7 +219,7 @@ struct JobsTests {
             cont.yield()
             throw FailedError()
         }
-        jobDefintion.options = [.doNotRetain]
+        jobDefintion.options = [.doNotRetainFailed]
         jobQueue.registerJob(jobDefintion)
 
         try await testJobQueue(jobQueue.processor(options: .init(numWorkers: 1))) {


### PR DESCRIPTION
This is primarily for internal jobs that users may not wanted recorded. eg the job cleaning up stalled processing jobs (which runs every 5 mins by default) and the general cleanup job which deletes old completed/cancelled jobs.

I added an OptionSet so we can add additional options later.  

Adding a new `retain` parameter to `failed(jobID:)` and `finished(jobID:)` in `JobQueueDriver` has meant I have had to do some awkward protocol updates to avoid a breaking change.